### PR TITLE
Basic Templates for Fieldset Labels

### DIFF
--- a/app/controllers/controller.js
+++ b/app/controllers/controller.js
@@ -15,12 +15,21 @@
     initArchetypeRenderModel();
     
     //helper to get $eval the labelExpression
-    $scope.getFieldsetTitle = function(expression, fieldsetIndex)
-    {
-        if(!expression) return "";
-        
-        return expression.replace(/\$fieldsetIndex/g, fieldsetIndex);
-    }
+    $scope.getFieldsetTitle = function(fieldsetConfigModel, fieldsetIndex) {
+        var fieldset = $scope.archetypeRenderModel.fieldsets[fieldsetIndex];
+        var template = fieldsetConfigModel.labelExpression;
+        var rgx = /{{(.*?)}}*/g;
+        var results;
+        var parsedTemplate = template;
+
+        while ((results = rgx.exec(template)) !== null) {
+            var propertyAlias = results[1];
+            var propertyValue = $scope.getPropertyValueByAlias(fieldset, propertyAlias);
+            parsedTemplate = parsedTemplate.replace(results[0], propertyValue);
+        }
+
+        return parsedTemplate;
+    };
 
     /* add/remove/sort */
 
@@ -112,6 +121,14 @@
             }
         }
     }
+
+    //helper to get a property by alias from a fieldset
+    $scope.getPropertyValueByAlias = function(fieldset, propertyAlias) {
+        var property = _.find(fieldset.properties, function(p) {
+            return p.alias == propertyAlias;
+        });
+        return (typeof property !== 'undefined') ? property.value : '';
+    };
     
     //helper for collapsing
     $scope.focusFieldset = function(fieldset){

--- a/app/views/archetype.html
+++ b/app/views/archetype.html
@@ -13,7 +13,7 @@
             <fieldset ng-class="fieldset.alias" ng-init="fieldsetConfigModel = getConfigFieldsetByAlias(fieldset.alias)">
                 <label ng-hide="model.config.hideFieldsetLabels == '1'" ng-click="focusFieldset(fieldset)">
                     <img ng-src='{{fieldsetConfigModel.icon}}' title="{{fieldsetConfigModel.tooltip}}"/>
-                    <span ng-bind="$parent.$eval(getFieldsetTitle(fieldsetConfigModel.labelExpression, $index))"></span>
+                    <span ng-bind="getFieldsetTitle(fieldsetConfigModel, $index)"></span>
                 </label>
                 <div class="archetypeEditorControls" ng-hide="model.config.hideFieldsetControls || model.config.maxFieldsets == '1'">
                     <i class="icon icon-add" ng-click="addRow(fieldset.alias, $index)" ng-show="canAdd()"></i>


### PR DESCRIPTION
The `Label Expr.` field can now be defined like this:  

```
Person: {{firstName}} {{lastName}}
```

Where firstName and lastName are the property alias of properties on the current fieldset

Note there's probably a more "angular" way to do this with `ng-bind-template`, but I couldn't really get going on that.  We could also get rid of the regex stuff if there's a way to access Angular's templating system via their API, similar to underscore's `_.template`, but I couldn't track that down either.  The good news is should be able to replace it at any time, because it uses the same handlebars-style templating syntax.
