### PR TITLE
Added 'repository' field to `packages.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,9 @@
     "grunt-touch": "~0.1.0",
     "fs-extra": "~0.8.1",
     "grunt-msbuild": "~0.1.9"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/imulus/Archetype.git"
   }
 }


### PR DESCRIPTION
Resolves #14 - I know it's such a minor tweak.

This removes npm's nag warning.
