### PR TITLE
Editor Control labels wired up fields/inputs

### DIFF
--- a/app/directives/archetypeproperty.js
+++ b/app/directives/archetypeproperty.js
@@ -110,7 +110,7 @@ angular.module("umbraco").directive('archetypeProperty', function ($compile, $ht
                     scope.model.config = config;
 
                     //some items need an alias
-                    scope.model.alias = "scope-" + scope.$id;
+                    scope.model.alias = "archetype-property-" + scope.fieldsetIndex + "-" + scope.propertyConfigIndex;
 
                     //watch for changes since there is no two-way binding with the local model.value
                     scope.$watch('model.value', function (newValue, oldValue) {

--- a/app/less/archetype.less
+++ b/app/less/archetype.less
@@ -45,6 +45,7 @@
         float: left;
         width: 80%;
         margin-bottom: 0;
+        margin-left: 5px;
         padding: 0;
     }
 }
@@ -91,6 +92,7 @@
 
 .archetypeEditor .archetypeDeveloperModel
 {
+    font-family: monospace;
     width: 98%;
     min-height: 100px;
     margin-bottom: 10px;

--- a/app/views/archetype.html
+++ b/app/views/archetype.html
@@ -1,13 +1,13 @@
 <div class="archetypeEditor ng-class:model.config.customCssClass" ng-controller="Imulus.ArchetypeController">
     <textarea class="archetypeDeveloperModel" ng-show="model.config.developerMode" ng-model="archetypeRenderModel"></textarea>
     <div class="archetypeFieldsetToolbar" ng-show="model.config.fieldsets.length > 1 && model.config.hideFieldsetToolbar != '1'">
-        <ul> 
+        <ul>
             <li ng-repeat="fieldsetModel in model.config.fieldsets" ng-click="addRow(fieldsetModel.alias)">
                 <i class="fieldsetIcon icon ng-class:fieldsetModel.icon"></i>
                 <span>{{fieldsetModel.label}}</span>
             </li>
         </ul>
-    </div> 
+    </div>
 
     <ul ui-sortable="sortableOptions" ng-model="archetypeRenderModel.fieldsets">
         <li ng-repeat="fieldset in archetypeRenderModel.fieldsets" ng-hide="fieldset.remove">
@@ -30,7 +30,7 @@
                 <div class="arechetypeCollapser animate-hide" ng-hide="fieldset.collapse">
                     <form class="form-inline">
                         <div ng-class="{archetypePropertyError: getPropertyValidity($parent.$index, property.alias) === false}" class="archetypeProperty control-group" ng-repeat="property in fieldsetConfigModel.properties">
-                            <label ng-hide="archetypeConfig.hidePropertyLabels == '1'" class="control-label" for="archetype-property-{{property.alias}}">
+                            <label ng-hide="archetypeConfig.hidePropertyLabels == '1'" class="control-label" for="archetype-property-{{$parent.$index}}-{{$index}}">
                                 <span>{{property.label}}</span>
                                 <div class="archetypeFieldsetHelpText" ng-show="property.helpText">
                                     <em>{{property.helpText}}</em>


### PR DESCRIPTION
On the property editor control, I have wired up the `<label for=>` value with the corresponding field's `id` attribute.

This was previously set as `'scope-' + scope.$id`, which wasn't accessible outside of the directive's scope.

The new value is based on the fieldset and property's index/position.
