### PR TITLE
Default fieldset title when empty

### DIFF
--- a/app/controllers/controller.js
+++ b/app/controllers/controller.js
@@ -18,7 +18,12 @@
     //helper to get $eval the labelTemplate
     $scope.getFieldsetTitle = function(fieldsetConfigModel, fieldsetIndex) {
         var fieldset = $scope.archetypeRenderModel.fieldsets[fieldsetIndex];
+        var fieldsetConfig = $scope.getConfigFieldsetByAlias(fieldset.alias);
         var template = fieldsetConfigModel.labelTemplate;
+
+        if (template.length < 1)
+            return fieldsetConfig.label;
+
         var rgx = /{{(.*?)}}*/g;
         var results;
         var parsedTemplate = template;


### PR DESCRIPTION
Shows the fieldset name (`label`) when the "Label Template" is empty.  I think it might be better than showing nothing.

![defaults](https://f.cloud.github.com/assets/1396376/2061397/ba8082fe-8c4f-11e3-9272-0c89d4a0b896.png)

Another future idea: show the first property value (or several) if the template is blank?
