### PR TITLE
Shorten up the prevalue editor fields for smaller screens

### DIFF
--- a/app/less/archetype.less
+++ b/app/less/archetype.less
@@ -163,7 +163,7 @@
 .archetypeConfig .archetypeFieldsetOption{
     margin-bottom: 15px;
     input[type=text]{
-        width: 600px;
+        max-width: 300px;
     }
 }
 
@@ -178,7 +178,7 @@
     border: 1px solid #ddd;
     padding: 8px;
     margin: -40px 10px 10px 140px;
-    width: 595px;
+    max-width: 475px;
 
     ul {
         padding: 0;
@@ -189,6 +189,15 @@
         padding: 10px;
         margin-bottom: 10px;
         background-color: #eee;
+
+        input[type=text] {
+            max-width: 190px;
+            width: auto;
+        }
+
+        select {
+            max-width: 160px;
+        }
     }
 
     li:last-child {


### PR DESCRIPTION
Quick fix to make things look a little better in smaller resolutions.

This makes the controls a bit shorter too, not sure how people feel about that.  This is just a quick fix until we can get @DillonMorton to save us :)

![shorten](https://f.cloud.github.com/assets/1396376/2061427/5c6dd0f2-8c51-11e3-8dea-bf6b0f03a89f.png)
