### PR TITLE
Fix some datatypes not working with multiple Archetypes

### DIFF
--- a/app/directives/archetypeproperty.js
+++ b/app/directives/archetypeproperty.js
@@ -55,6 +55,7 @@ angular.module("umbraco.directives").directive('archetypeProperty', function ($c
         var config = null;
         var alias = configFieldsetModel.properties[scope.propertyConfigIndex].alias;
         var defaultValue = configFieldsetModel.properties[scope.propertyConfigIndex].value;
+        var umbracoPropertyAlias = scope.umbracoPropertyAlias;
 
         //try to convert the defaultValue to a JS object
         defaultValue = jsonOrString(defaultValue, scope.archetypeConfig.developerMode, "defaultValue");
@@ -81,7 +82,7 @@ angular.module("umbraco.directives").directive('archetypeProperty', function ($c
                 }
                 var mergedConfig = _.extend(defaultConfigObj, config);
 
-                loadView(pathToView, mergedConfig, defaultValue, alias, scope, element, ngModelCtrl);
+                loadView(pathToView, mergedConfig, defaultValue, alias, umbracoPropertyAlias, scope, element, ngModelCtrl);
             });
         });
 
@@ -111,7 +112,7 @@ angular.module("umbraco.directives").directive('archetypeProperty', function ($c
         }
     }
 
-    function loadView(view, config, defaultValue, alias, scope, element, ngModelCtrl) {
+    function loadView(view, config, defaultValue, alias, umbracoPropertyAlias, scope, element, ngModelCtrl) {
         if (view)
         {
             $http.get(view).success(function (data) {
@@ -139,7 +140,7 @@ angular.module("umbraco.directives").directive('archetypeProperty', function ($c
                     scope.model.config = config;
 
                     //some items need an alias
-                    scope.model.alias = "archetype-property-" + scope.fieldsetIndex + "-" + scope.propertyConfigIndex;
+                    scope.model.alias = "archetype-property-" + umbracoPropertyAlias + "-" + scope.fieldsetIndex + "-" + scope.propertyConfigIndex;
 
                     //watch for changes since there is no two-way binding with the local model.value
                     scope.$watch('model.value', function (newValue, oldValue) {
@@ -167,7 +168,8 @@ angular.module("umbraco.directives").directive('archetypeProperty', function ($c
             archetypeConfig: '=',
             fieldset: '=',
             fieldsetIndex: '=',
-            archetypeRenderModel: '='
+            archetypeRenderModel: '=',
+            umbracoPropertyAlias: '='
         }
     }
 });

--- a/app/views/archetype.html
+++ b/app/views/archetype.html
@@ -30,7 +30,7 @@
                 <div class="archetypeCollapser animate-hide" ng-hide="fieldset.collapse">
                     <form class="form-inline">
                         <div ng-class="{archetypePropertyError: getPropertyValidity($parent.$index, property.alias) === false}" class="archetypeProperty control-group" ng-repeat="property in fieldsetConfigModel.properties">
-                            <label ng-hide="archetypeConfig.hidePropertyLabels == '1'" class="control-label" for="archetype-property-{{$parent.$index}}-{{$index}}">
+                            <label ng-hide="archetypeConfig.hidePropertyLabels == '1'" class="control-label" for="archetype-property-{{model.alias}}-{{$parent.$index}}-{{$index}}">
                                 <span>{{property.label}}</span>
                                 <div class="archetypeFieldsetHelpText" ng-show="property.helpText">
                                     <em>{{property.helpText}}</em>
@@ -38,7 +38,7 @@
                             </label>
 
                             <div class="controls">
-                                <archetype-property class="archetypeEditor ng-class:property.alias" property="property" fieldset-index="$parent.$index" fieldset="fieldset" archetype-config="model.config" property-config-index="$index" archetype-render-model="archetypeRenderModel"></archetype-property>
+                                <archetype-property class="archetypeEditor ng-class:property.alias" property="property" fieldset-index="$parent.$index" fieldset="fieldset" archetype-config="model.config" property-config-index="$index" archetype-render-model="archetypeRenderModel" umbraco-property-alias="model.alias"></archetype-property>
                             </div>
                         </div>
                     </form>


### PR DESCRIPTION
Some Umbraco PropertyEditors rely on the ID of the property as they're doing DOM lookups on them - [example (DatePicker)](https://github.com/umbraco/Umbraco-CMS/blob/7.0.4/src/Umbraco.Web.UI.Client/src/views/propertyeditors/datepicker/datepicker.controller.js#L56)

This adds the Archetype's Property Alias (from Umbraco) to the unique ID we generate for each property we render.

_Example:_
Old: `archetype-property-0-0`
New: `archetype-property-sliderItems-0-0`

This should fix #50 and #51 

Need to DRY this up later ;)
