### PR TITLE
Resolves #34 "2500 limit" issue

### DIFF
--- a/app/Umbraco/Umbraco.Archetype/Application.cs
+++ b/app/Umbraco/Umbraco.Archetype/Application.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Umbraco.Core;
+using Umbraco.Core.Logging;
+
+namespace Archetype.Umbraco
+{
+	public class Application : ApplicationEventHandler
+	{
+		protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
+		{
+			base.ApplicationStarted(umbracoApplication, applicationContext);
+
+			ExpandPrevalueValueColumnSize();
+		}
+
+		protected void ExpandPrevalueValueColumnSize()
+		{
+			try
+			{
+				var dbContext = ApplicationContext.Current.DatabaseContext;
+				var colCount =
+					dbContext.Database.ExecuteScalar<int>(
+						"SELECT COUNT(1) FROM INFORMATION_SCHEMA.COLUMNS WHERE DATA_TYPE = 'nvarchar' AND COLUMN_NAME = 'value' AND CHARACTER_MAXIMUM_LENGTH = 2500 AND TABLE_NAME = 'cmsDataTypePreValues'");
+
+				// Check column
+				if (colCount != 0)
+				{
+					using (var trans = dbContext.Database.GetTransaction())
+					{
+						// Change column
+						dbContext.Database.Execute("ALTER TABLE [cmsDataTypePreValues] ALTER COLUMN [value] ntext NULL;");
+
+						trans.Complete();
+					}
+
+					LogHelper.Debug(typeof(Application), "Successfully expanded Prevalue table Value column");
+				}
+				else
+				{
+					LogHelper.Debug(typeof(Application), "Prevalue table Value column is already expanded");
+				}
+			}
+			catch (Exception ex)
+			{
+				LogHelper.Error(typeof(Application), "Error expanding Prevalue table Value column", ex);
+			}
+		}
+	}
+}

--- a/app/Umbraco/Umbraco.Archetype/Archetype.Umbraco.csproj
+++ b/app/Umbraco/Umbraco.Archetype/Archetype.Umbraco.csproj
@@ -114,6 +114,7 @@
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.4.0.30506.0\lib\net40\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Web.Helpers, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>True</Private>
       <HintPath>..\packages\Microsoft.AspNet.WebPages.2.0.30506.0\lib\net40\System.Web.Helpers.dll</HintPath>
@@ -184,6 +185,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Application.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Extensions\Extensions.cs" />
     <Compile Include="Models\Archetype.cs" />


### PR DESCRIPTION
Added application start-up event to check the data-type's prevalue column size.

If the prevalue column is set to be `nvarchar(2500)`, then the column is altered to be `ntext`.

The `ExpandPrevalueValueColumnSize` method is written by @mattbrailsford (credit goes to him).

Hopefully this code will resolve issue #34 
