### PR TITLE
Add version # to DLL on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ pkg/*.zip
 [Bb]in/
 [Oo]bj/
 [Pp]ackages/
+VersionInfo.cs
 
 *.aps
 *.bak

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,6 +5,7 @@ module.exports = function(grunt) {
     dest: 'dist',
     package_dir: 'pkg',
     package_temp_dir: '<%= package_dir %>/tmp/',
+    csProj: 'app/Umbraco/Umbraco.Archetype/Archetype.Umbraco.csproj',
 
 
     watch: {
@@ -161,16 +162,28 @@ module.exports = function(grunt) {
       package_artifacts: ['pkg/*.zip', 'pkg/*.nupkg'],
     },
 
+    assemblyinfo: {
+        options: {
+            files: ['<%= csProj %>'],
+            filename: 'VersionInfo.cs',
+            info: {
+                version: '<%= (pkgMeta.version.indexOf("-") ? pkgMeta.version.substring(0, pkgMeta.version.indexOf("-")) : pkgMeta.version) %>', 
+                fileVersion: '<%= pkgMeta.version %>'
+            }
+        }
+    },
+
     msbuild: {
         dev: {
-            src: ['app/Umbraco/Umbraco.Archetype/Archetype.Umbraco.csproj'],
+            src: ["<%= csProj %>"],
             options: {
                 projectConfiguration: 'Debug',
                 targets: ['Clean', 'Rebuild'],
                 stdout: true,
                 maxCpuCount: 4,
                 buildParameters: {
-                    WarningLevel: 2
+                    WarningLevel: 2,
+                    NoWarn: 1607,
                 },
                 verbosity: 'quiet'
             }
@@ -190,6 +203,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-template');
   grunt.loadNpmTasks('grunt-touch');
   grunt.loadNpmTasks('grunt-msbuild');
+  grunt.loadNpmTasks('grunt-dotnet-assembly-info');
   grunt.loadTasks('tasks');
 
 
@@ -200,6 +214,7 @@ module.exports = function(grunt) {
   grunt.registerTask('deploy', ['default', 'copy:deploy', 'touchwebconfigifenabled']);
   grunt.registerTask('css:build', ['less']);
   grunt.registerTask('js:build', ['concat']);
-  grunt.registerTask('default', ['clean', 'css:build', 'js:build', 'copy:build', 'msbuild:dev']);
+  grunt.registerTask('cs:build', ['assemblyinfo', 'msbuild:dev']);
+  grunt.registerTask('default', ['clean', 'css:build', 'js:build', 'copy:build', 'cs:build']);
 };
 

--- a/app/Umbraco/Umbraco.Archetype/Archetype.Umbraco.csproj
+++ b/app/Umbraco/Umbraco.Archetype/Archetype.Umbraco.csproj
@@ -228,6 +228,7 @@
     <Compile Include="Models\Fieldset.cs" />
     <Compile Include="Models\Property.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\VersionInfo.cs" />
     <Compile Include="PropertyConverters\ArchetypeValueConverter.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/app/Umbraco/Umbraco.Archetype/Properties/AssemblyInfo.cs
+++ b/app/Umbraco/Umbraco.Archetype/Properties/AssemblyInfo.cs
@@ -12,7 +12,3 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible(false)]
 [assembly: Guid("E37E94F9-C7BA-4B54-B7E1-64419B3DBA0B")]
-
-[assembly: AssemblyVersion("0.1.0.0")]
-[assembly: AssemblyFileVersion("0.1.0.0")]
-[assembly: AssemblyInformationalVersion("0.1.0-alpha")]

--- a/app/Umbraco/Umbraco.Archetype/Properties/VersionInfo.cs
+++ b/app/Umbraco/Umbraco.Archetype/Properties/VersionInfo.cs
@@ -1,0 +1,4 @@
+﻿using System.Reflection;
+
+[assembly: AssemblyVersion("0.0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0.0")]

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "grunt-template": "~0.2.2",
     "grunt-touch": "~0.1.0",
     "fs-extra": "~0.8.1",
-    "grunt-msbuild": "~0.1.9"
+    "grunt-msbuild": "~0.1.9",
+    "grunt-dotnet-assembly-info": "~1.0.9"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Split VersionInfo from `AssemblyInfo.cs` so we can ignore changes and let the build handle
- Ignore `VersionInfo.cs`
- Install/configure assemblyinfo grunt task
- Ignore compiler warning about bad version number format (.NET vs SemVer)

![2014-02-22_0-37-31](https://f.cloud.github.com/assets/1396376/2237199/39e1c762-9b94-11e3-8e66-f16e3d9c09bb.png)

Note, C# doesn't like the `-alpha` flag that SemVer supports, so we're chopping it off for the one field we can't use it in ("File Version").  Will still show the full version in the "Product Version" field.  It also doesn't really like it in the Product Version field, but I've ignored the compiler warning for now :sunglasses: 
