### PR TITLE
Add hack for #53 - attempt to resolve promises manually

### DIFF
--- a/app/directives/archetypeproperty.js
+++ b/app/directives/archetypeproperty.js
@@ -1,4 +1,4 @@
-angular.module("umbraco.directives").directive('archetypeProperty', function ($compile, $http, archetypePropertyEditorResource, umbPropEditorHelper) {
+angular.module("umbraco.directives").directive('archetypeProperty', function ($compile, $http, archetypePropertyEditorResource, umbPropEditorHelper, $timeout, $rootScope, $q) {
     
     function getFieldsetByAlias(fieldsets, alias)
     {
@@ -152,6 +152,12 @@ angular.module("umbraco.directives").directive('archetypeProperty', function ($c
 
                     element.html(data).show();
                     $compile(element.contents())(scope);
+
+                    $timeout(function() {
+                        var def = $q.defer();
+                        def.resolve(true);
+                        $rootScope.$apply();
+                    }, 500)
                 }
             });
         }


### PR DESCRIPTION
$compile no longer unwraps promises, meaning some property editors may not fully load when a new fieldset is added (their various .then() methods never get executed).  This attempts to resolve them after a delay.  Could be intermittent, but seems to work in most cases.

Workaround for #53
