### PR TITLE
Auto-fill fieldset and property aliases in Config

### DIFF
--- a/app/controllers/config.controller.js
+++ b/app/controllers/config.controller.js
@@ -124,6 +124,24 @@ angular.module("umbraco").controller("Imulus.ArchetypeConfigController", functio
         }
     });
     
+    $scope.autoPopulateAlias = function(s) {
+        var modelType = s.hasOwnProperty('fieldset') ? 'fieldset' : 'property';
+        var modelProperty = s[modelType];
+
+        if (!modelProperty.aliasIsDirty) {
+            modelProperty.alias = modelProperty.label.toUmbracoAlias();
+        }
+    }
+
+    $scope.markAliasDirty = function(s) {
+        var modelType = s.hasOwnProperty('fieldset') ? 'fieldset' : 'property';
+        var modelProperty = s[modelType];
+
+        if (!modelProperty.aliasIsDirty) {
+            modelProperty.aliasIsDirty = true;;
+        }
+    }
+
     //helper that returns if an item can be removed
     $scope.canRemoveFieldset = function ()
     {   
@@ -224,6 +242,8 @@ angular.module("umbraco").controller("Imulus.ArchetypeConfigController", functio
         _.each($scope.archetypeConfigRenderModel.fieldsets, function(fieldset){
 
             fieldset.remove = false;
+            if (fieldset.alias.length > 0)
+                fieldset.aliasIsDirty = true;
 
             if(fieldset.label)
             {
@@ -232,6 +252,8 @@ angular.module("umbraco").controller("Imulus.ArchetypeConfigController", functio
 
             _.each(fieldset.properties, function(fieldset){
                 fieldset.remove = false;
+                if (fieldset.alias.length > 0)
+                    fieldset.aliasIsDirty = true;
             });
         });
     }

--- a/app/views/archetype.config.html
+++ b/app/views/archetype.config.html
@@ -11,11 +11,11 @@
                 <div class="archetypeFieldsetCollapser" ng-hide="fieldset.collapse && fieldset.label">
                     <div class="archetypeFieldsetOption">
                         <label for="archetypeFieldLabel_{{$index}}"><archetype-localize key="label">Label</archetype-localize></label>
-                        <input type="text" id="archetypeFieldLabel_{{$index}}" ng-model="fieldset.label" />
+                        <input type="text" id="archetypeFieldLabel_{{$index}}" ng-model="fieldset.label" on-keyup="autoPopulateAlias(this)" />
                     </div>
                     <div class="archetypeFieldsetOption">
                         <label for="archetypeFieldAlias_{{$index}}"><archetype-localize key="alias">Alias</archetype-localize></label>
-                        <input type="text" id="archetypeFieldAlias_{{$index}}" ng-model="fieldset.alias" required/>
+                        <input type="text" id="archetypeFieldAlias_{{$index}}" ng-model="fieldset.alias" on-keyup="markAliasDirty(this)" required/>
                     </div>
                     <div class="archetypeFieldsetOption">
                         <label for="archetypeFieldLabelTemplate_{{$index}}"><archetype-localize key="labelTemplate">Label Template</archetype-localize></label>
@@ -42,11 +42,11 @@
                                 <div class="archetypePropertyCollapser" ng-hide="property.collapse && property.label">
                                     <div>
                                         <label for="archetypePropertyLabel_{{$parent.$index}}_{{$index}}"><archetype-localize key="label">Label</archetype-localize></label>
-                                        <input type="text" id="archetypePropertyLabel_{{$parent.$index}}_{{$index}}" ng-model="property.label" />
+                                        <input type="text" id="archetypePropertyLabel_{{$parent.$index}}_{{$index}}" ng-model="property.label" on-keyup="autoPopulateAlias(this)"/>
                                     </div>
                                     <div>
                                         <label for="archetypePropertyAlias_{{$parent.$index}}_{{$index}}"><archetype-localize key="alias">Alias</archetype-localize></label>
-                                        <input type="text" id="archetypePropertyAlias_{{$parent.$index}}_{{$index}}" ng-model="property.alias" required/>
+                                        <input type="text" id="archetypePropertyAlias_{{$parent.$index}}_{{$index}}" ng-model="property.alias" on-keyup="markAliasDirty(this)" required/>
                                     </div>
                                     <div>
                                         <label for="archetypePropertyHelpText_{{$parent.$index}}_{{$index}}"><archetype-localize key="helpText">Help Text</archetype-localize></label>


### PR DESCRIPTION
![autopopulate-sm](https://f.cloud.github.com/assets/1396376/2306087/33d0ee16-a279-11e3-906e-13e9bc663677.gif)

Fixes #32 
- Add new aliasIsDirty property, init for existing data
- Bind label control's keyup to populate the `alias` property (when it's not dirty) using Umbraco's helpers
- Mark alias dirty on keyup
