### PR TITLE
Add hack to workaround U4-4181 (Firefox can't click any fields)

### DIFF
--- a/app/controllers/controller.js
+++ b/app/controllers/controller.js
@@ -133,6 +133,7 @@
     
     //helper for expanding/collapsing fieldsets
     $scope.focusFieldset = function(fieldset){
+        fixDisableSelection();
         
         var iniState;
         
@@ -260,6 +261,16 @@
             
             return model;
         }
+    }
+
+    // Hack for U4-4281 / #61
+    function fixDisableSelection() {
+        $timeout(function() {
+            $('.archetypeEditor .controls')
+                .bind('mousedown.ui-disableSelection selectstart.ui-disableSelection', function(e) { 
+                    e.stopImmediatePropagation();
+                }); 
+        }, 1000);
     }
 
     //helper to lookup validity when given a fieldsetIndex and property alias


### PR DESCRIPTION
...in lieu of "proper" fix in Umbraco.

This is really shiesty, but seems to work in most cases, so might be better than nothing :)

Fixes #61
