### PR TITLE
Property's help text tag to match Umbraco style

### DIFF
--- a/app/views/archetype.html
+++ b/app/views/archetype.html
@@ -36,7 +36,7 @@
                             <label ng-hide="archetypeConfig.hidePropertyLabels == '1'" class="control-label" for="archetype-property-{{model.alias}}-{{$parent.$index}}-{{$index}}">
                                 <span>{{property.label}}</span>
                                 <div class="archetypeFieldsetHelpText" ng-show="property.helpText">
-                                    <em>{{property.helpText}}</em>
+                                    <small>{{property.helpText}}</small>
                                 </div>
                             </label>
 


### PR DESCRIPTION
Changed the property's help-text tag from `<em>` to `<small>` - to match Umbraco's native style.

![capture](https://f.cloud.github.com/assets/209066/2402475/898e1c06-aa22-11e3-84a5-3492b1777a62.PNG)
