### PR TITLE
Fix Umbraco's error style propagating to elements in our view

### DIFF
--- a/app/less/archetype.less
+++ b/app/less/archetype.less
@@ -263,6 +263,13 @@
     border: 1px solid #b94a48;
 }
 
+.archetypeEditor .archetypeProperty {
+    label {
+        span {
+            color: #343434;
+        }
+    }
+}
 .archetypeEditor .archetypePropertyError{
     margin-bottom: 5px;
     padding-top: 3px;


### PR DESCRIPTION
Should fix the issue described in [this thread](http://our.umbraco.org/projects/backoffice-extensions/archetype/sound-off!/49058-Validation-seems-to-have-minor-issues?p=0), where valid properties are highlighted, due to one of Umbraco's styles propagating into our view when it recognizes the Umbraco property is invalid (after a Save)
