### PR TITLE
Add "Hide Label" option for full-width Archetypes

### DIFF
--- a/app/controllers/controller.js
+++ b/app/controllers/controller.js
@@ -1,6 +1,7 @@
 ﻿angular.module("umbraco").controller("Imulus.ArchetypeController", function ($scope, $http, assetsService, angularHelper, notificationsService, $timeout) {
  
     //$scope.model.value = "";
+    $scope.model.hideLabel = $scope.model.config.hideLabel == 1;
 
     //get a reference to the current form
     var form = angularHelper.getCurrentForm($scope);

--- a/app/package.manifest
+++ b/app/package.manifest
@@ -19,6 +19,12 @@
 								type: "Required"         
 							}   
 						]
+					},
+					{
+						label: "Hide Label",
+						description: "Hide the Umbraco property title and description, making the Archetype span the entire page width",
+						key: "hideLabel",
+						view: "boolean"
 					}
 				]
 			}


### PR DESCRIPTION
Adds a Prevalue Option to hide the Umbraco property label, allowing the Archetype to span the full width of the page:

![2014-03-14_22-35-23](https://f.cloud.github.com/assets/1396376/2427624/59a9cbf4-abfb-11e3-88ac-72267fa58c5e.png)
