### PR TITLE
Allow single rows to be collapsed

### DIFF
--- a/app/controllers/controller.js
+++ b/app/controllers/controller.js
@@ -152,16 +152,16 @@
         }
     
         _.each($scope.archetypeRenderModel.fieldsets, function(fieldset){
-            if($scope.archetypeRenderModel.fieldsets.length == 1 && fieldset.remove == false)
-            {
-                fieldset.collapse = false;
-                return;
-            }
-        
             fieldset.collapse = true;
         });
         
-        if(iniState)
+        if(!fieldset && $scope.archetypeRenderModel.fieldsets.length == 1 && $scope.archetypeRenderModel.fieldsets[0].remove == false)
+        {
+            $scope.archetypeRenderModel.fieldsets[0].collapse = false;
+            return;
+        }
+        
+        if(iniState && fieldset)
         {
             fieldset.collapse = !iniState;
         }


### PR DESCRIPTION
Previously, you couldn't collapse a single row by itself, it was always expanded.  Now you can collapse it, but it's still expanded on the initial page load.

If you don't want single rows to be collapsible, you can still use the "Enable Collapsing" option

I'm not quite sure if there's a use case here, it was just bugging me that I couldn't collapse it when collapsing was enabled :)
