### PR TITLE
Changed data types storage to store guids instead of ids

### DIFF
--- a/app/Umbraco/Umbraco.Archetype/Api/ArchetypeDataTypeController.cs
+++ b/app/Umbraco/Umbraco.Archetype/Api/ArchetypeDataTypeController.cs
@@ -1,4 +1,6 @@
-﻿using System.Net;
+﻿using System;
+using System.Linq;
+using System.Net;
 using System.Web.Http;
 using AutoMapper;
 using Umbraco.Core.Models;
@@ -11,9 +13,15 @@ namespace Archetype.Umbraco.Api
     [PluginController("ArchetypeApi")]
     public class ArchetypeDataTypeController : UmbracoAuthorizedJsonController
     {
-        public object GetById(int id)
+        public object GetAll() 
         {
-            var dataType = Services.DataTypeService.GetDataTypeDefinitionById(id);
+            var dataTypes = Services.DataTypeService.GetAllDataTypeDefinitions();
+            return dataTypes.Select(t => new { guid = t.Key, name = t.Name });
+        }
+
+        public object GetByGuid(Guid guid)
+        {
+            var dataType = Services.DataTypeService.GetDataTypeDefinitionById(guid);
             if (dataType == null)
             {
                 throw new HttpResponseException(HttpStatusCode.NotFound);

--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypePreValueProperty.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypePreValueProperty.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace Archetype.Umbraco.Models
 {
@@ -18,12 +19,9 @@ namespace Archetype.Umbraco.Models
 
         [JsonProperty("helpText")]
         public string HelpText { get; set; }
-
-        [JsonProperty("dataTypeId")]
-        public int DataTypeId { get; set; }
-
+        
         [JsonProperty("dataTypeGuid")]
-        public string DataTypeGuid { get; set; }
+        public Guid DataTypeGuid { get; set; }
 
         [JsonProperty("propertyEditorAlias")]
         public string PropertyEditorAlias { get; set; }

--- a/app/Umbraco/Umbraco.Archetype/PropertyConverters/ArchetypeValueConverter.cs
+++ b/app/Umbraco/Umbraco.Archetype/PropertyConverters/ArchetypeValueConverter.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Archetype.Umbraco.Extensions;
 using Archetype.Umbraco.Models;
 using Newtonsoft.Json;
 using Umbraco.Core;
+using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.PropertyEditors;
 using Umbraco.Core.Services;
@@ -55,7 +57,8 @@ namespace Archetype.Umbraco.PropertyConverters
                     {
                         // Get list of configured properties and their types 
                         // and map them to the deserialized archetype model
-                        var preValue = GetArchetypePreValueFromDataTypeId(propertyType.DataTypeId);
+                        var dataTypeCache = new Dictionary<Guid, IDataTypeDefinition>();
+                        var preValue = GetArchetypePreValueFromDataTypeId(propertyType.DataTypeId, dataTypeCache);
                         foreach (var fieldset in preValue.Fieldsets)
                         {
                             var fieldsetAlias = fieldset.Alias;
@@ -66,7 +69,7 @@ namespace Archetype.Umbraco.PropertyConverters
                                     var propertyAlias = property.Alias;
                                     foreach (var propertyInst in fieldsetInst.Properties.Where(x => x.Alias == propertyAlias))
                                     {
-                                        propertyInst.DataTypeId = property.DataTypeId;
+                                        propertyInst.DataTypeId = GetDataTypeByGuid(property.DataTypeGuid, dataTypeCache).Id;
                                         propertyInst.PropertyEditorAlias = property.PropertyEditorAlias;
                                     }
                                 }
@@ -88,7 +91,7 @@ namespace Archetype.Umbraco.PropertyConverters
             return defaultValue;
         }
 
-        internal ArchetypePreValue GetArchetypePreValueFromDataTypeId(int dataTypeId)
+        private ArchetypePreValue GetArchetypePreValueFromDataTypeId(int dataTypeId, IDictionary<Guid, IDataTypeDefinition> dataTypeCache)
         {
             var preValues = Services.DataTypeService.GetPreValuesCollectionByDataTypeId(dataTypeId);
 
@@ -102,18 +105,22 @@ namespace Archetype.Umbraco.PropertyConverters
             {
                 foreach (var property in fieldset.Properties)
                 {
-                    // Lookup the properties property editor alias
-                    // (See if we've already looked it up first though to save a database hit)
-                    var propertyWithSameDataType = config.Fieldsets.SelectMany(x => x.Properties)
-                        .FirstOrDefault(x => x.DataTypeId == property.DataTypeId && !string.IsNullOrWhiteSpace(x.PropertyEditorAlias));
-
-                    property.PropertyEditorAlias = propertyWithSameDataType != null
-                        ? propertyWithSameDataType.PropertyEditorAlias
-                        : Services.DataTypeService.GetDataTypeDefinitionById(property.DataTypeId).PropertyEditorAlias;
+                    property.PropertyEditorAlias = GetDataTypeByGuid(property.DataTypeGuid, dataTypeCache).PropertyEditorAlias;
                 }
             }
 
             return config;
+        }
+
+        private IDataTypeDefinition GetDataTypeByGuid(Guid guid, IDictionary<Guid, IDataTypeDefinition> cache)
+        {
+            IDataTypeDefinition dataType;
+            if (cache.TryGetValue(guid, out dataType))
+                return dataType;
+
+            dataType = Services.DataTypeService.GetDataTypeDefinitionById(guid);
+            cache[guid] = dataType;
+            return dataType;
         }
     }
 }

--- a/app/controllers/config.controller.js
+++ b/app/controllers/config.controller.js
@@ -4,7 +4,7 @@ angular.module("umbraco").controller("Imulus.ArchetypeConfigController", functio
     //console.log($scope.model.value); 
 
     //define empty items
-    var newPropertyModel = '{"alias": "", "remove": false, "collapse": false, "label": "", "helpText": "", "dataTypeId": "-88", "value": ""}';
+    var newPropertyModel = '{"alias": "", "remove": false, "collapse": false, "label": "", "helpText": "", "dataTypeGuid": "0CC0EBA1-9960-42C9-BF9B-60E150B429AE", "value": ""}';
     var newFieldsetModel = '{"alias": "", "remove": false, "collapse": false, "labelTemplate": "", "icon": "", "label": "", "properties": [' + newPropertyModel + ']}';
     var defaultFieldsetConfigModel = JSON.parse('{"showAdvancedOptions": false, "hideFieldsetToolbar": false, "enableMultipleFieldsets": false, "hideFieldsetControls": false, "hidePropertyLabel": false, "maxFieldsets": null, "enableCollapsing": true, "fieldsets": [' + newFieldsetModel + ']}');
 
@@ -166,12 +166,12 @@ angular.module("umbraco").controller("Imulus.ArchetypeConfigController", functio
         return countVisibleProperty(fieldset) > 1;
     }
 
-    $scope.getDataTypeNameById = function (id) {
+    $scope.getDataTypeNameByGuid = function (guid) {
         if ($scope.availableDataTypes == null) // Might not be initialized yet?
             return "";
-
+        
         var dataType = _.find($scope.availableDataTypes, function(d) {
-            return d.id == id;
+            return d.guid == guid;
         });
 
         return dataType == null ? "" : dataType.name;

--- a/app/directives/archetypeproperty.js
+++ b/app/directives/archetypeproperty.js
@@ -51,7 +51,7 @@ angular.module("umbraco.directives").directive('archetypeProperty', function ($c
         var configFieldsetModel = getFieldsetByAlias(scope.archetypeConfig.fieldsets, scope.fieldset.alias);
         var view = "";
         var label = configFieldsetModel.properties[scope.propertyConfigIndex].label;
-        var dataTypeId = configFieldsetModel.properties[scope.propertyConfigIndex].dataTypeId;
+        var dataTypeGuid = configFieldsetModel.properties[scope.propertyConfigIndex].dataTypeGuid;
         var config = null;
         var alias = configFieldsetModel.properties[scope.propertyConfigIndex].alias;
         var defaultValue = configFieldsetModel.properties[scope.propertyConfigIndex].value;
@@ -61,7 +61,7 @@ angular.module("umbraco.directives").directive('archetypeProperty', function ($c
         defaultValue = jsonOrString(defaultValue, scope.archetypeConfig.developerMode, "defaultValue");
 
         //grab info for the selected datatype, prepare for view
-        archetypePropertyEditorResource.getDataType(dataTypeId).then(function (data) {
+        archetypePropertyEditorResource.getDataType(dataTypeGuid).then(function (data) {
             //transform preValues array into object expected by propertyeditor views
             var configObj = {};
             _.each(data.preValues, function(p) {

--- a/app/resources/propertyeditor.js
+++ b/app/resources/propertyeditor.js
@@ -3,16 +3,12 @@ angular.module('umbraco.resources').factory('archetypePropertyEditorResource', f
         getAllDataTypes: function() {
             // Hack - grab DataTypes from Tree API, as `dataTypeService.getAll()` isn't implemented yet
             return umbRequestHelper.resourcePromise(
-                $http.get("/umbraco/backoffice/UmbracoTrees/DataTypeTree/GetNodes?id=-1&application=developer&tree=&isDialog=false"), 'Failed to retrieve datatypes from tree service'
-            ).then(function (data) {
-                return data.map(function(d) {
-                    return { "id": d.id, "name": d.name }
-                }); 
-            });
+                $http.get("/umbraco/backoffice/ArchetypeApi/ArchetypeDataType/GetAll"), 'Failed to retrieve datatypes from tree service'
+            );
         },
-        getDataType: function(id) {
+        getDataType: function(guid) {
         	return umbRequestHelper.resourcePromise(
-        		$http.get("/umbraco/backoffice/ArchetypeApi/ArchetypeDataType/GetById?id=" + id), 'Failed to retrieve datatype'
+        		$http.get("/umbraco/backoffice/ArchetypeApi/ArchetypeDataType/GetByGuid?guid=" + guid), 'Failed to retrieve datatype'
     		);
         },
         getPropertyEditorMapping: function(alias) {

--- a/app/views/archetype.config.html
+++ b/app/views/archetype.config.html
@@ -37,7 +37,7 @@
                                     <i class="icon icon-navigation handle" ng-show="canSortProperty(fieldset)"></i>
                                 </div>
                                 <div class="archetypePropertyTitle" ng-click="focusProperty(fieldset.properties, property)">
-                                    {{property.label}} ({{property.alias}}) - <span>{{getDataTypeNameById(property.dataTypeId)}}</span>
+                                    {{property.label}} ({{property.alias}}) - <span>{{getDataTypeNameByGuid(property.dataTypeGuid)}}</span>
                                 </div>
                                 <div class="archetypePropertyCollapser" ng-hide="property.collapse && property.label">
                                     <div>
@@ -54,7 +54,7 @@
                                     </div>
                                     <div>
                                         <label for="archetypePropertyDataType_{{$parent.$index}}_{{$index}}"><archetype-localize key="dataType">Datatype</archetype-localize></label>
-                                        <select id="archetypePropertyDataType_{{$parent.$index}}_{{$index}}" ng-model="property.dataTypeId" ng-options="datatype.id as datatype.name for datatype in availableDataTypes"></select>
+                                        <select id="archetypePropertyDataType_{{$parent.$index}}_{{$index}}" ng-model="property.dataTypeGuid" ng-options="datatype.guid as datatype.name for datatype in availableDataTypes | orderBy:'name'"></select>
                                     </div>
                                     <div>
                                         <label for="archetypePropertyDefaultValue_{{$parent.$index}}_{{$index}}"><archetype-localize key="defaultValue">Default Value</archetype-localize></label>


### PR DESCRIPTION
As discussed in #92.

One thing that I do not fully understand is why `Property.DataTypeId` is serializable -- I left is as-is though, as either way only the definition/prevalues matter for the sync.
