### PR TITLE
Added a "Start with Add button" option

### DIFF
--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypePreValue.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypePreValue.cs
@@ -8,6 +8,9 @@ namespace Archetype.Umbraco.Models
         [JsonProperty("showAdvancedOptions")]
         public bool ShowAdvancedOptions { get; set; }
 
+        [JsonProperty("startWithAddButton")]
+        public bool StartWithAddButton { get; set; }
+
         [JsonProperty("hideFieldsetToolbar")]
         public bool HideFieldsetToolbar { get; set; }
 

--- a/app/controllers/config.controller.js
+++ b/app/controllers/config.controller.js
@@ -1,19 +1,19 @@
 angular.module("umbraco").controller("Imulus.ArchetypeConfigController", function ($scope, $http, assetsService, dialogService, archetypePropertyEditorResource) {
-    
-    //$scope.model.value = ""; 
-    //console.log($scope.model.value); 
+
+    //$scope.model.value = "";
+    //console.log($scope.model.value);
 
     //define empty items
     var newPropertyModel = '{"alias": "", "remove": false, "collapse": false, "label": "", "helpText": "", "dataTypeId": "-88", "value": ""}';
     var newFieldsetModel = '{"alias": "", "remove": false, "collapse": false, "labelTemplate": "", "icon": "", "label": "", "properties": [' + newPropertyModel + ']}';
-    var defaultFieldsetConfigModel = JSON.parse('{"showAdvancedOptions": false, "hideFieldsetToolbar": false, "enableMultipleFieldsets": false, "hideFieldsetControls": false, "hidePropertyLabel": false, "maxFieldsets": null, "enableCollapsing": true, "fieldsets": [' + newFieldsetModel + ']}');
+    var defaultFieldsetConfigModel = JSON.parse('{"showAdvancedOptions": false, "startWithAddButton": false, "hideFieldsetToolbar": false, "enableMultipleFieldsets": false, "hideFieldsetControls": false, "hidePropertyLabel": false, "maxFieldsets": null, "enableCollapsing": true, "fieldsets": [' + newFieldsetModel + ']}');
 
     //ini the model
     $scope.model.value = $scope.model.value || defaultFieldsetConfigModel;
-    
+
     //ini the render model
     initConfigRenderModel();
- 
+
     //get the available datatypes
     archetypePropertyEditorResource.getAllDataTypes().then(function(data) {
         $scope.availableDataTypes = data;
@@ -40,16 +40,16 @@ angular.module("umbraco").controller("Imulus.ArchetypeConfigController", functio
 
         }
     };
-    
+
     //function that determines how to manage expanding/collapsing fieldsets
     $scope.focusFieldset = function(fieldset){
         var iniState;
-        
+
         if(fieldset)
         {
             iniState = fieldset.collapse;
         }
-        
+
         _.each($scope.archetypeConfigRenderModel.fieldsets, function(fieldset){
             if($scope.archetypeConfigRenderModel.fieldsets.length == 1 && fieldset.remove == false)
             {
@@ -66,7 +66,7 @@ angular.module("umbraco").controller("Imulus.ArchetypeConfigController", functio
                 fieldset.collapse = false;
             }
         });
-        
+
         if(iniState)
         {
             fieldset.collapse = !iniState;
@@ -79,7 +79,7 @@ angular.module("umbraco").controller("Imulus.ArchetypeConfigController", functio
     //function that determines how to manage expanding/collapsing properties
     $scope.focusProperty = function(properties, property){
         var iniState;
-        
+
         if(property)
         {
             iniState = property.collapse;
@@ -95,7 +95,7 @@ angular.module("umbraco").controller("Imulus.ArchetypeConfigController", functio
                 property.collapse = false;
             }
         });
-        
+
         if(iniState)
         {
             property.collapse = !iniState;
@@ -106,24 +106,24 @@ angular.module("umbraco").controller("Imulus.ArchetypeConfigController", functio
     _.each($scope.archetypeConfigRenderModel.fieldsets, function(fieldset){
             $scope.focusProperty(fieldset.properties);
     });
-    
+
     //setup JSON.stringify helpers
     $scope.archetypeConfigRenderModel.toString = stringify;
-    
+
     //encapsulate stringify (should be built into browsers, not sure of IE support)
     function stringify() {
         return JSON.stringify(this);
     }
-    
+
     //watch for changes
     $scope.$watch('archetypeConfigRenderModel', function (v) {
         //console.log(v);
-        if (typeof v === 'string') {     
+        if (typeof v === 'string') {
             $scope.archetypeConfigRenderModel = JSON.parse(v);
             $scope.archetypeConfigRenderModel.toString = stringify;
         }
     });
-    
+
     $scope.autoPopulateAlias = function(s) {
         var modelType = s.hasOwnProperty('fieldset') ? 'fieldset' : 'property';
         var modelProperty = s[modelType];
@@ -144,7 +144,7 @@ angular.module("umbraco").controller("Imulus.ArchetypeConfigController", functio
 
     //helper that returns if an item can be removed
     $scope.canRemoveFieldset = function ()
-    {   
+    {
         return countVisibleFieldset() > 1;
     }
 
@@ -153,10 +153,10 @@ angular.module("umbraco").controller("Imulus.ArchetypeConfigController", functio
     {
         return countVisibleFieldset() > 1;
     }
-    
+
     //helper that returns if an item can be removed
     $scope.canRemoveProperty = function (fieldset)
-    {   
+    {
         return countVisibleProperty(fieldset) > 1;
     }
 
@@ -176,7 +176,7 @@ angular.module("umbraco").controller("Imulus.ArchetypeConfigController", functio
 
         return dataType == null ? "" : dataType.name;
     }
-    
+
     //helper to count what is visible
     function countVisibleFieldset()
     {
@@ -190,7 +190,7 @@ angular.module("umbraco").controller("Imulus.ArchetypeConfigController", functio
 
         return count;
     }
-    
+
     //determines how many properties are visible
     function countVisibleProperty(fieldset)
     {
@@ -204,13 +204,13 @@ angular.module("umbraco").controller("Imulus.ArchetypeConfigController", functio
 
         return count;
     }
-   
+
     //handles a fieldset add
     $scope.addFieldsetRow = function ($index, $event) {
         $scope.archetypeConfigRenderModel.fieldsets.splice($index + 1, 0, JSON.parse(newFieldsetModel));
         $scope.focusFieldset();
     }
-    
+
     //rather than splice the archetypeConfigRenderModel, we're hiding this and cleaning onFormSubmitting
     $scope.removeFieldsetRow = function ($index) {
         if ($scope.canRemoveFieldset()) {
@@ -219,12 +219,12 @@ angular.module("umbraco").controller("Imulus.ArchetypeConfigController", functio
             }
         }
     }
-    
+
     //handles a property add
     $scope.addPropertyRow = function (fieldset, $index) {
         fieldset.properties.splice($index + 1, 0, JSON.parse(newPropertyModel));
     }
-    
+
     //rather than splice the archetypeConfigRenderModel, we're hiding this and cleaning onFormSubmitting
     $scope.removePropertyRow = function (fieldset, $index) {
         if ($scope.canRemoveProperty(fieldset)) {
@@ -233,7 +233,7 @@ angular.module("umbraco").controller("Imulus.ArchetypeConfigController", functio
             }
         }
     }
-    
+
     //helper to ini the render model
     function initConfigRenderModel()
     {
@@ -257,38 +257,38 @@ angular.module("umbraco").controller("Imulus.ArchetypeConfigController", functio
             });
         });
     }
-    
+
     //sync things up on save
     $scope.$on("formSubmitting", function (ev, args) {
         syncModelToRenderModel();
     });
-    
+
     //helper to sync the model to the renderModel
     function syncModelToRenderModel()
     {
         $scope.model.value = $scope.archetypeConfigRenderModel;
         var fieldsets = [];
-        
+
         _.each($scope.archetypeConfigRenderModel.fieldsets, function(fieldset){
             //check fieldsets
             if (!fieldset.remove) {
                 fieldsets.push(fieldset);
-                
+
                 var properties = [];
 
                 _.each(fieldset.properties, function(property){
                    if (!property.remove) {
                         properties.push(property);
-                    } 
+                    }
                 });
 
                 fieldset.properties = properties;
             }
         });
-        
+
         $scope.model.value.fieldsets = fieldsets;
     }
-    
+
     //archetype css
     assetsService.loadCss("/App_Plugins/Archetype/css/archetype.css");
 });

--- a/app/less/archetype.less
+++ b/app/less/archetype.less
@@ -36,7 +36,7 @@
         cursor: pointer;
 
         label  {
-            span { 
+            span {
                 text-decoration: underline;
             }
             &:hover {
@@ -294,6 +294,14 @@
             color: #b94a48;
             font-weight: bold;
         }
+    }
+}
+
+.archetypeEditor .archetypeAddButton:hover {
+    text-decoration: none;
+
+    .archetypeAddButtonText {
+        text-decoration: underline;
     }
 }
 

--- a/app/views/archetype.config.html
+++ b/app/views/archetype.config.html
@@ -27,7 +27,7 @@
                     </div>
                     <div class="archetypeFieldsetOption">
                         <label><archetype-localize key="properties">Properties</archetype-localize></label>
-                    </div> 
+                    </div>
                     <div class="archetypePropertiesWrapper">
                         <ul ui-sortable="sortableOptions" ng-model="fieldset.properties">
                             <li ng-repeat="property in fieldset.properties" ng-hide="property.remove">
@@ -82,6 +82,10 @@
 
     <div class="archetypeAdvancedOptions" ng-show="archetypeConfigRenderModel.showAdvancedOptions">
         <div>
+            <label for="archetypeAdvancedOptionsStartWithAddButton"><archetype-localize key="startWithAddButton">Start With Add Button?</archetype-localize><small><archetype-localize key="startWithAddButtonDescription">Empty property shows an add button instead of providing a default fieldset.</archetype-localize></small></label>
+            <input type="checkbox" id="archetypeAdvancedOptionsStartWithAddButton" ng-model="archetypeConfigRenderModel.startWithAddButton"/>
+        </div>
+        <div>
             <label for="archetypeAdvancedOptionsHideControls"><archetype-localize key="hideFieldsetControls">Hide Fieldset Controls?</archetype-localize><small><archetype-localize key="hideFieldsetControlsDescription">Hides the fieldset add/remove/sort controls.</archetype-localize></small></label>
             <input type="checkbox" id="archetypeAdvancedOptionsHideControls" ng-model="archetypeConfigRenderModel.hideFieldsetControls"/>
         </div>
@@ -96,11 +100,11 @@
         <div>
             <label for="archetypeAdvancedOptionsMultipleFieldsets"><archetype-localize key="enableMultipleFieldsets">Enable Multiple Fieldsets?</archetype-localize><small><archetype-localize key="enableMultipleFieldsetsDescription">Allows multiple types of fieldsets within this archetype.</archetype-localize></small></label>
             <input type="checkbox" id="archetypeAdvancedOptionsMultipleFieldsets" ng-model="archetypeConfigRenderModel.enableMultipleFieldsets"/>
-        </div> 
+        </div>
         <div>
             <label for="archetypeAdvancedOptionsCollapsing"><archetype-localize key="enableCollapsing">Enable Collapsing?</archetype-localize><small><archetype-localize key="enableCollapsingDescription">Allows multiple types of fieldsets within this archetype.</archetype-localize></small></label>
             <input type="checkbox" id="archetypeAdvancedOptionsCollapsing" ng-model="archetypeConfigRenderModel.enableCollapsing"/>
-        </div> 
+        </div>
         <div>
             <label for="archetypeAdvancedOptionsFieldsetToolbar"><archetype-localize key="hideFieldsetToolbar">Hide Fieldset Toolbar?</archetype-localize><small><archetype-localize key="hideFieldsetToolbarDescription">Hides the fieldset toolbar that appears when more than one fieldset model appears.</archetype-localize></small></label>
             <input type="checkbox" id="archetypeAdvancedOptionsFieldsetToolbar" ng-model="archetypeConfigRenderModel.hideFieldsetToolbar"/>

--- a/app/views/archetype.html
+++ b/app/views/archetype.html
@@ -9,7 +9,7 @@
         </ul>
     </div>
 
-    <ul ui-sortable="sortableOptions" ng-model="archetypeRenderModel.fieldsets">
+    <ul ui-sortable="sortableOptions" ng-model="archetypeRenderModel.fieldsets" ng-show="!showAddButton()">
         <li ng-repeat="fieldset in archetypeRenderModel.fieldsets" ng-hide="fieldset.remove">
             <fieldset ng-class="{archetypeFieldsetError: !fieldset.isValid}" ng-init="fieldsetConfigModel = getConfigFieldsetByAlias(fieldset.alias)">
 
@@ -49,4 +49,11 @@
             </fieldset>
         </li>
     </ul>
+
+    <div ng-show="showAddButton()">
+        <a class="archetypeAddButton" href="#" ng-click="addRow(model.config.fieldsets[0].alias, 0)" prevent-default="">
+            <i class="icon icon-add"></i>
+            <localize key="general_add" class="archetypeAddButtonText">Add</localize>
+        </a>
+    </div>
 </div>


### PR DESCRIPTION
This option causes Archetype to show "+ Add" button instead of default fieldset.
The button is only shown if there are no fieldsets -- subsequent fieldsets are added using standard control bar.

There are two reasons for that:
1. I find undeletable default fieldset confusing.
2. It completely sidesteps issue imulus/Archetype#68.  
   Proper fix for that issue is rather hard as some editors may change fields on their own when loaded.

The UI design is:
![Add button design](https://cloud.githubusercontent.com/assets/166396/2586655/fe30ecb6-ba06-11e3-9cd1-52febad2a383.png)
