### PR TITLE
Show "remove" button when MaxFieldsets = 1 and Multiple Fieldset Types

### DIFF
--- a/app/controllers/controller.js
+++ b/app/controllers/controller.js
@@ -93,7 +93,8 @@
     //helper that returns if an item can be removed
     $scope.canRemove = function ()
     {
-        return countVisible() > 1
+        return countVisible() > 1 
+            || ($scope.model.config.maxFieldsets == 1 && $scope.model.config.fieldsets.length > 1)
             || $scope.model.config.startWithAddButton;
     }
 


### PR DESCRIPTION
... so the user can switch types (remove/add) when only a single row.

We check for Multiple Fieldset Types as well, because we don't want to show a "remove" button when there's only one type allowed (presumably).

Fixes #109
