### PR TITLE
Save JSON configuration prevalue to database

### DIFF
--- a/app/Umbraco/Umbraco.Archetype/Archetype.Umbraco.csproj
+++ b/app/Umbraco/Umbraco.Archetype/Archetype.Umbraco.csproj
@@ -209,9 +209,11 @@
   <ItemGroup>
     <Compile Include="Api\ArchetypeDataTypeController.cs" />
     <Compile Include="Constants.cs" />
+    <Compile Include="Database\DatabaseHelper.cs" />
     <Compile Include="Events\ExpireCache.cs" />
     <Compile Include="Extensions\ArchetypeHelper.cs" />
     <Compile Include="Extensions\Extensions.cs" />
+    <Compile Include="Install\InstallActions.cs" />
     <Compile Include="Models\Archetype.cs" />
     <Compile Include="Models\ArchetypePreValue.cs" />
     <Compile Include="Models\ArchetypePreValueFieldset.cs" />
@@ -221,6 +223,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\VersionInfo.cs" />
     <Compile Include="PropertyConverters\ArchetypeValueConverter.cs" />
+    <Compile Include="Database\ArchetypeConfiguration.cs" />
     <Compile Include="PropertyEditors\ArchetypePropertyEditor.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -230,6 +233,10 @@
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
+  <PropertyGroup>
+    <PostBuildEvent>
+    </PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/app/Umbraco/Umbraco.Archetype/Database/ArchetypeConfiguration.cs
+++ b/app/Umbraco/Umbraco.Archetype/Database/ArchetypeConfiguration.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.DatabaseAnnotations;
+
+namespace Archetype.Umbraco.Database
+{
+    [TableName("Archetype")]
+    [PrimaryKey("Id", autoIncrement = false)]
+    [ExplicitColumns]
+    public class ArchetypeConfiguration
+    {
+        [Column("Id")]
+        [PrimaryKeyColumn(AutoIncrement = false)]
+        public Guid Id { get; set; }
+
+        [Column("Configuration")]
+        [SpecialDbType(SpecialDbTypes.NTEXT)]
+        public string Configuration { get; set; }
+    }
+}

--- a/app/Umbraco/Umbraco.Archetype/Database/DatabaseHelper.cs
+++ b/app/Umbraco/Umbraco.Archetype/Database/DatabaseHelper.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Umbraco.Core;
+using Umbraco.Core.Persistence;
+
+namespace Archetype.Umbraco.Database
+{
+    internal class DatabaseHelper
+    {
+        public static UmbracoDatabase UmbracoDatabase
+        {
+            get
+            {
+                return ApplicationContext.Current.DatabaseContext.Database;
+            }
+        }
+
+        public static ArchetypeConfiguration Get(Guid guid)
+        {
+            return UmbracoDatabase.FirstOrDefault<ArchetypeConfiguration>(string.Format("WHERE Id = '{0}'", guid));
+        }
+
+        public static void Add(ArchetypeConfiguration configuration)
+        {
+            UmbracoDatabase.Insert(configuration);
+        }
+
+        public static void Update(ArchetypeConfiguration configuration)
+        {
+            UmbracoDatabase.Update(configuration);
+        }
+
+        public static void Install()
+        {
+            if(UmbracoDatabase.TableExist("Archetype") == false)
+            {
+                UmbracoDatabase.CreateTable<ArchetypeConfiguration>();
+            }
+        }
+
+        public static void Uninstall()
+        {
+            if(UmbracoDatabase.TableExist("Archetype"))
+            {
+                UmbracoDatabase.DropTable<ArchetypeConfiguration>();
+            }
+        }
+    }
+}

--- a/app/Umbraco/Umbraco.Archetype/Install/InstallActions.cs
+++ b/app/Umbraco/Umbraco.Archetype/Install/InstallActions.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Xml.Linq;
+using umbraco.interfaces;
+using Umbraco.Web;
+using Umbraco.Core.Persistence;
+using Umbraco.Core.Persistence.DatabaseAnnotations;
+using Archetype.Umbraco.Database;
+
+namespace Archetype.Umbraco.Install
+{
+    // create/drop Archetype table on package install/uninstall
+    public class InstallActions : IPackageAction
+    {
+        public string Alias()
+        {
+            return "ArchetypeInstall";
+        }
+
+        public bool Execute(string packageName, System.Xml.XmlNode xmlData)
+        {
+            DatabaseHelper.Install();
+            return true;
+        }
+
+        public System.Xml.XmlNode SampleXml()
+        {
+            var element = XElement.Parse(string.Format(@"<Action runat=""install"" undo=""true"" alias=""{0}"" />", Alias()));
+            using(var xmlReader = element.CreateReader())
+            {
+                var xmlDoc = new XmlDocument();
+                xmlDoc.Load(xmlReader);
+                return xmlDoc;
+            }
+        }
+
+        public bool Undo(string packageName, System.Xml.XmlNode xmlData)
+        {
+            DatabaseHelper.Uninstall();
+            return true;
+        }
+    }
+
+}

--- a/app/Umbraco/Umbraco.Archetype/PropertyEditors/ArcheTypePropertyEditor.cs
+++ b/app/Umbraco/Umbraco.Archetype/PropertyEditors/ArcheTypePropertyEditor.cs
@@ -11,6 +11,7 @@ using Umbraco.Core.Models.Editors;
 using Umbraco.Core.PropertyEditors;
 using Umbraco.Core.Services;
 using Umbraco.Web.PropertyEditors;
+using Archetype.Umbraco.Database;
 
 namespace Archetype.Umbraco.PropertyEditors
 {
@@ -35,6 +36,88 @@ namespace Archetype.Umbraco.PropertyEditors
 			[PreValueField("hideLabel", "Hide Label", "boolean",
 				Description = "Hide the Umbraco property title and description, making the Archetype span the entire page width")]
 			public bool HideLabel { get; set; }
+
+            public override IDictionary<string, object> ConvertDbToEditor(IDictionary<string, object> defaultPreVals, PreValueCollection persistedPreVals)
+            {
+                if(persistedPreVals != null & persistedPreVals.PreValuesAsDictionary != null && persistedPreVals.PreValuesAsDictionary.ContainsKey(Constants.PreValueAlias))
+                {
+                    // convert the persisted prevalues to a dictionary and get the config prevalue
+                    var preValues = persistedPreVals.PreValuesAsDictionary.ToDictionary(i => i.Key, i => i.Value);
+                    var config = preValues[Constants.PreValueAlias];
+
+                    Guid configurationId;
+                    if(Guid.TryParse(config.Value, out configurationId))
+                    {
+                        // if the config prevalue is a GUID, try to get the Archetype configuration from DB and update the config prevalue to the stored Archetype configuration
+                        var configuration = DatabaseHelper.Get(configurationId);
+                        if(configuration != null)
+                        {                            
+                            preValues[Constants.PreValueAlias] = new PreValue(config.Id, configuration.Configuration, config.SortOrder);
+                        }
+                        else
+                        {
+                            // this shouldn't happen, but just in case... return an empty string as Archetype configuration - this will cause the client to use the default configuration
+                            preValues[Constants.PreValueAlias] = new PreValue(config.Id, string.Empty, config.SortOrder);
+                        }
+
+                        // update the prevalues before letting the base class convert them to editor
+                        persistedPreVals.PreValuesAsDictionary = preValues;
+                    }
+                }
+
+                var baseConversion = base.ConvertDbToEditor(defaultPreVals, persistedPreVals);
+                return baseConversion;
+            }
+
+            public override IDictionary<string, PreValue> ConvertEditorToDb(IDictionary<string, object> editorValue, PreValueCollection currentValue)
+            {
+                // first let the base class convert the prevalues to DB
+                var baseConversion = base.ConvertEditorToDb(editorValue, currentValue).ToDictionary(i => i.Key, i => i.Value);
+
+                if(baseConversion.ContainsKey(Constants.PreValueAlias))
+                {
+                    // get the config prevalue
+                    var config = baseConversion[Constants.PreValueAlias];
+
+                    // generate a new configuration ID for this configuration
+                    var configurationId = Guid.NewGuid();
+                    ArchetypeConfiguration configuration = null;
+
+                    // is this an update of an existing configuration?
+                    if(currentValue != null && currentValue.PreValuesAsDictionary != null && currentValue.PreValuesAsDictionary.ContainsKey(Constants.PreValueAlias))
+                    {
+                        // yes, do we already have a configuration stored in DB (is the current prevalue a GUID)?
+                        if(Guid.TryParse(currentValue.PreValuesAsDictionary[Constants.PreValueAlias].Value, out configurationId))
+                        {
+                            // yes, get the currently stored configuration
+                            configuration = DatabaseHelper.Get(configurationId);
+                        }
+                    }
+
+                    // do we have an existing configuration in DB?
+                    if(configuration == null)
+                    {
+                        // no, create a new
+                        configuration = new ArchetypeConfiguration
+                        {
+                            Id = configurationId,
+                            Configuration = config.Value
+                        };
+                        DatabaseHelper.Add(configuration);
+                    }
+                    else
+                    {
+                        // yes, update the existing configuration
+                        configuration.Configuration = config.Value;
+                        DatabaseHelper.Update(configuration);
+                    }
+
+                    // store the configuration ID as prevalue 
+                    baseConversion[Constants.PreValueAlias] = new PreValue(config.Id, configurationId.ToString(), config.SortOrder);
+                }
+
+                return baseConversion;
+            }
 		}
 
 		#endregion
@@ -120,5 +203,5 @@ namespace Archetype.Umbraco.PropertyEditors
 		}
 
 		#endregion	
-	}
+    }
 }

--- a/config/package.xml
+++ b/config/package.xml
@@ -26,7 +26,9 @@
   <Languages />
   <DataTypes />
   <control />
-  <Actions />
+  <Actions>
+    <Action runat="install" undo="true" alias="ArchetypeInstall" />
+  </Actions>
   <files>
   	<% files.forEach(function(file) { %>
   	<file>


### PR DESCRIPTION
As described in issue #34 (imulus#34) the Archetype configuration quickly exceeds the 2500 characters allowed by Umbraco prevalues.
This pull request implements a solution to the problem by moving the Archetype JSON configuration to a separate custom table within the Umbraco database, and solely using the Umbraco prevalue as an identifier to find the Archetype configuration in the new table.
The custom table gets created automatically when the package is installed, and dropped from the database when the package is uninstalled.
