### PR TITLE
Implement #116 - Add RegEx validation to properties

### DIFF
--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypePreValueProperty.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypePreValueProperty.cs
@@ -31,5 +31,8 @@ namespace Archetype.Umbraco.Models
 
         [JsonProperty("required")]
         public bool Required { get; set; }
+
+        [JsonProperty("regEx")]
+        public bool RegEx { get; set; }
     }
 }

--- a/app/directives/archetypeproperty.js
+++ b/app/directives/archetypeproperty.js
@@ -97,10 +97,22 @@ angular.module("umbraco.directives").directive('archetypeProperty', function ($c
                     property.isValid = true;
 
                     var propertyConfig = getPropertyByAlias(configFieldsetModel, property.alias);
-                    if(propertyConfig && propertyConfig.required && (property.value == null || property.value === "")){
-                        fieldset.isValid = false;
-                        property.isValid = false;
-                        valid = false;
+                    if (propertyConfig) {
+                        if(propertyConfig.required && (property.value == null || property.value === "")) {
+                            fieldset.isValid = false;
+                            property.isValid = false;
+                            valid = false;
+                        }
+                        // issue 116: RegEx validate property value
+                        // Only validate the property value if anything has been entered - RegEx is considered a supplement to "required".
+                        if (valid == true && propertyConfig.regEx && property.value) {
+                            var regEx = new RegExp(propertyConfig.regEx);
+                            if (regEx.test(property.value) == false) {
+                                fieldset.isValid = false;
+                                property.isValid = false;
+                                valid = false;
+                            }
+                        }
                     }
                 });
             });

--- a/app/langs/da-dk.js
+++ b/app/langs/da-dk.js
@@ -27,6 +27,7 @@
 	"defaultValue": "Standard værdi",
 	"dataType": "Datatype",
 	"required": "Påkrævet",
+	"regEx": "RegEx validering",
 	"properties": "Egenskaber",
 	"labelTemplate": "Label skabelon",
 	"select": "Vælg",

--- a/app/langs/de-de.js
+++ b/app/langs/de-de.js
@@ -27,6 +27,7 @@
 	"defaultValue": "Default Value",
 	"dataType": "DataType",
 	"required": "Required",
+	"regEx": "RegEx Validation",
 	"properties": "Properties",
 	"labelTemplate": "Label Template",
 	"select": "Select",

--- a/app/langs/en-gb.js
+++ b/app/langs/en-gb.js
@@ -27,6 +27,7 @@
 	"defaultValue": "Default Value",
 	"dataType": "DataType",
 	"required": "Required",
+	"regEx": "RegEx Validation",
 	"properties": "Properties",
 	"labelTemplate": "Label Template",
 	"select": "Select",

--- a/app/langs/en-us.js
+++ b/app/langs/en-us.js
@@ -27,6 +27,7 @@
 	"defaultValue": "Default Value",
 	"dataType": "DataType",
 	"required": "Required",
+	"regEx": "RegEx Validation",
 	"properties": "Properties",
 	"labelTemplate": "Label Template",
 	"select": "Select",

--- a/app/langs/es-es.js
+++ b/app/langs/es-es.js
@@ -27,6 +27,7 @@
 	"defaultValue": "Default Value",
 	"dataType": "DataType",
 	"required": "Required",
+	"regEx": "RegEx Validation",
 	"properties": "Properties",
 	"labelTemplate": "Label Template",
 	"select": "Select",

--- a/app/langs/fr-fr.js
+++ b/app/langs/fr-fr.js
@@ -27,6 +27,7 @@
 	"defaultValue": "Default Value",
 	"dataType": "DataType",
 	"required": "Required",
+	"regEx": "RegEx Validation",
 	"properties": "Properties",
 	"labelTemplate": "Label Template",
 	"select": "Select",

--- a/app/langs/he-il.js
+++ b/app/langs/he-il.js
@@ -27,6 +27,7 @@
 	"defaultValue": "Default Value",
 	"dataType": "DataType",
 	"required": "Required",
+	"regEx": "RegEx Validation",
 	"properties": "Properties",
 	"labelTemplate": "Label Template",
 	"select": "Select",

--- a/app/langs/it-it.js
+++ b/app/langs/it-it.js
@@ -27,6 +27,7 @@
 	"defaultValue": "Default Value",
 	"dataType": "DataType",
 	"required": "Required",
+	"regEx": "RegEx Validation",
 	"properties": "Properties",
 	"labelTemplate": "Label Template",
 	"select": "Select",

--- a/app/langs/ja-jp.js
+++ b/app/langs/ja-jp.js
@@ -27,6 +27,7 @@
 	"defaultValue": "Default Value",
 	"dataType": "DataType",
 	"required": "Required",
+	"regEx": "RegEx Validation",
 	"properties": "Properties",
 	"labelTemplate": "Label Template",
 	"select": "Select",

--- a/app/langs/ko-kr.js
+++ b/app/langs/ko-kr.js
@@ -27,6 +27,7 @@
 	"defaultValue": "Default Value",
 	"dataType": "DataType",
 	"required": "Required",
+	"regEx": "RegEx Validation",
 	"properties": "Properties",
 	"labelTemplate": "Label Template",
 	"select": "Select",

--- a/app/langs/nb-no.js
+++ b/app/langs/nb-no.js
@@ -27,6 +27,7 @@
 	"defaultValue": "Default Value",
 	"dataType": "DataType",
 	"required": "Required",
+	"regEx": "RegEx Validation",
 	"properties": "Properties",
 	"labelTemplate": "Label Template",
 	"select": "Select",

--- a/app/langs/nl-nl.js
+++ b/app/langs/nl-nl.js
@@ -27,6 +27,7 @@
 	"defaultValue": "Default Value",
 	"dataType": "DataType",
 	"required": "Required",
+	"regEx": "RegEx Validation",
 	"properties": "Properties",
 	"labelTemplate": "Label Template",
 	"select": "Select",

--- a/app/langs/pl-pl.js
+++ b/app/langs/pl-pl.js
@@ -27,6 +27,7 @@
 	"defaultValue": "Default Value",
 	"dataType": "DataType",
 	"required": "Required",
+	"regEx": "RegEx Validation",
 	"properties": "Properties",
 	"labelTemplate": "Label Template",
 	"select": "Select",

--- a/app/langs/pt-br.js
+++ b/app/langs/pt-br.js
@@ -27,6 +27,7 @@
 	"defaultValue": "Default Value",
 	"dataType": "DataType",
 	"required": "Required",
+	"regEx": "RegEx Validation",
 	"properties": "Properties",
 	"labelTemplate": "Label Template",
 	"select": "Select",

--- a/app/langs/ru-ru.js
+++ b/app/langs/ru-ru.js
@@ -27,6 +27,7 @@
 	"defaultValue": "Default Value",
 	"dataType": "DataType",
 	"required": "Required",
+	"regEx": "RegEx Validation",
 	"properties": "Properties",
 	"labelTemplate": "Label Template",
 	"select": "Select",

--- a/app/langs/sv-se.js
+++ b/app/langs/sv-se.js
@@ -27,6 +27,7 @@
 	"defaultValue": "Default Value",
 	"dataType": "DataType",
 	"required": "Required",
+	"regEx": "RegEx Validation",
 	"properties": "Properties",
 	"labelTemplate": "Label Template",
 	"select": "Select",

--- a/app/langs/zh-cn.js
+++ b/app/langs/zh-cn.js
@@ -27,6 +27,7 @@
 	"defaultValue": "Default Value",
 	"dataType": "DataType",
 	"required": "Required",
+	"regEx": "RegEx Validation",
 	"properties": "Properties",
 	"labelTemplate": "Label Template",
 	"select": "Select",

--- a/app/views/archetype.config.html
+++ b/app/views/archetype.config.html
@@ -64,6 +64,10 @@
                                         <label for="archetypePropertyRequired_{{$parent.$index}}_{{$index}}"><archetype-localize key="required">Required</archetype-localize></label>
                                         <input type="checkbox" id="archetypePropertyRequired_{{$parent.$index}}_{{$index}}" ng-model="property.required" />
                                     </div>
+                                    <div>
+                                        <label for="archetypePropertyRegEx_{{$parent.$index}}_{{$index}}"><archetype-localize key="regEx">RegEx Validation</archetype-localize></label>
+                                        <input type="text" id="archetypePropertyRegExValue_{{$parent.$index}}_{{$index}}" ng-model="property.regEx" />
+                                    </div>
                                 </div>
                             </li>
                         </ul>


### PR DESCRIPTION
This implements support for RegEx validation for each property in a fieldset. 
The RegEx validation is implemented as a supplement to the "required" validation; thus RegEx validation is only performed if the property actually has a value. This way we can have optional properties that conform to a RexEx validation if filled out.
Localized the input field label for Danish, default English localization for the rest of the languages.
