### PR TITLE
Stop prompting to discard changes (again)

### DIFF
--- a/app/directives/archetypeproperty.js
+++ b/app/directives/archetypeproperty.js
@@ -157,8 +157,11 @@ angular.module("umbraco.directives").directive('archetypeProperty', function ($c
                     scope.$watch('model.value', function (newValue, oldValue) {
                         scope.archetypeRenderModel.fieldsets[scope.fieldsetIndex].properties[renderModelPropertyIndex].value = newValue;
 
-                        //trigger the validation pipeline
-                        ngModelCtrl.$setViewValue(ngModelCtrl.$viewValue);
+                        // don't set the current value twice - this will keep Umbraco from prompting to discard changes immediately after saving
+                        if (newValue != oldValue) {
+                            //trigger the validation pipeline
+                            ngModelCtrl.$setViewValue(ngModelCtrl.$viewValue);
+                        }
                     });
 
                     element.html(data).show();


### PR DESCRIPTION
Once more :) an attempt to solve the problem of Umbraco continuously prompting to discard changes after saving (issue #121). 

This time around it's tested with 3 level deep nested Archetypes composed by both built in PE's and a custom PE. 

And yes, it shouldn't really be Archetype's responsibility to handle this, but if this simple fix can do the trick, I think a bunch of editors will be happy.

![archetypes in archetype in archetype](https://cloud.githubusercontent.com/assets/7405322/2949456/2bb6ca48-da0f-11e3-85ad-8a17b02cffa0.png)
