### PR TITLE
Ensure row changes are not discarded by accident

### DIFF
--- a/app/controllers/controller.js
+++ b/app/controllers/controller.js
@@ -43,7 +43,7 @@
         cursor: "move",
         handle: ".handle",
         update: function (ev, ui) {
-
+            $scope.setDirty();
         },
         stop: function (ev, ui) {
 
@@ -67,6 +67,7 @@
                     $scope.model.value.fieldsets.push(newFieldset);
                 }
             }
+            $scope.setDirty();
 
             newFieldset.collapse = $scope.model.config.enableCollapsing ? true : false;
             $scope.focusFieldset(newFieldset);
@@ -76,6 +77,7 @@
     $scope.removeRow = function ($index) {
         if ($scope.canRemove()) {
             if (confirm('Are you sure you want to remove this?')) {
+                $scope.setDirty();
                 $scope.model.value.fieldsets.splice($index, 1);
             }
         }
@@ -259,6 +261,13 @@
         }
 
         return (typeof property == 'undefined') ? true : property.isValid;
+    }
+
+    // helper to force the current form into the dirty state
+    $scope.setDirty = function () {
+        if($scope.form) {
+            $scope.form.$setDirty();
+        }
     }
 
     //custom js


### PR DESCRIPTION
Fix for #123. By forcing the PE form in dirty state after removing or reordering the rows, Umbraco will prompt the editor to discard changes if the editor navigates away from the document without saving the row changes.
