### PR TITLE
Fix deserialization of RegEx enabled properties

### DIFF
--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypePreValueProperty.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypePreValueProperty.cs
@@ -33,6 +33,6 @@ namespace Archetype.Models
         public bool Required { get; set; }
 
         [JsonProperty("regEx")]
-        public bool RegEx { get; set; }
+        public string RegEx { get; set; }
     }
 }


### PR DESCRIPTION
Fix type mismatch for RegEx (introduced in 6e50301). My bad, sorry... for whatever reason, the RegEx property on the model ended up as a boolean property instead of a string property. 
