### PR TITLE
Fix unit tests

### DIFF
--- a/app/Umbraco/Umbraco.Archetype/PropertyConverters/ArchetypeValueConverter.cs
+++ b/app/Umbraco/Umbraco.Archetype/PropertyConverters/ArchetypeValueConverter.cs
@@ -34,7 +34,7 @@ namespace Archetype.PropertyConverters
             if (!sourceString.DetectIsJson())
                 return defaultValue;
 
-            using (var timer = DisposableTimer.DebugDuration<ArchetypeValueConverter>(string.Format("ConvertDataToSource ({0})", propertyType.PropertyTypeAlias)))
+			using (var timer = DisposableTimer.DebugDuration<ArchetypeValueConverter>(string.Format("ConvertDataToSource ({0})", propertyType != null ? propertyType.PropertyTypeAlias : "null")))
             {
                 var archetype = ArchetypeHelper.Instance.DeserializeJsonToArchetype(sourceString,
                     (propertyType != null ? propertyType.DataTypeId : -1),


### PR DESCRIPTION
The call to `DisposableTimer.DebugDuration()` in `ArchetypeValueConverter.ConvertDataToSource()` expects the `propertyType` parameter to be not null, but the implementation of `ArchetypeValueConverter.ConvertDataToSource()` allows the `propertyType` parameter to be null. This breaks some of the unit tests.
I've added a null check in the call to `DisposableTimer.DebugDuration()` to counter this issue.
