### PR TITLE
Fix #212 - Implement InGroupsOf extension

### DIFF
--- a/app/Umbraco/Archetype.Tests/Archetype.Tests.csproj
+++ b/app/Umbraco/Archetype.Tests/Archetype.Tests.csproj
@@ -219,6 +219,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions\EnumerableExtensionsTests.cs" />
     <Compile Include="Models\FieldsetTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PropertyValueConverter\PropertyValueConverterTests.cs" />

--- a/app/Umbraco/Archetype.Tests/Extensions/EnumerableExtensionsTests.cs
+++ b/app/Umbraco/Archetype.Tests/Extensions/EnumerableExtensionsTests.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Archetype.Extensions;
+using Archetype.PropertyConverters;
+using NUnit.Framework;
+
+namespace Archetype.Tests.Extensions
+{
+	[TestFixture]
+	class EnumerableExtensionsTests
+	{
+		[Test]
+		public void Can_Get_List_In_Groups_Of_Three()
+		{
+			var items = new List<string> { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" };
+			var groups = items.InGroupsOf(3);
+			Assert.AreEqual(4, groups.Count());
+			Assert.AreEqual("1, 2, 3", string.Join(", ", groups.First()));
+			Assert.AreEqual("4, 5, 6", string.Join(", ", groups.Skip(1).First()));
+			Assert.AreEqual("7, 8, 9", string.Join(", ", groups.Skip(2).First()));
+			Assert.AreEqual("10", string.Join(", ", groups.Last()));
+		}
+
+		[Test]
+		public void Can_Get_List_In_Groups_Of_Five()
+		{
+			var items = new List<string> { "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" };
+			var groups = items.InGroupsOf(5);
+			Assert.AreEqual(2, groups.Count());
+			Assert.AreEqual("1, 2, 3, 4, 5", string.Join(", ", groups.First()));
+			Assert.AreEqual("6, 7, 8, 9, 10", string.Join(", ", groups.Last()));
+		}
+
+		[Test]
+		public void Can_Get_List_In_Groups_Of_More_Than_It_Contains()
+		{
+			var items = new List<string> { "1", "2", "3", "4" };
+			var groups = items.InGroupsOf(100);
+			Assert.AreEqual(1, groups.Count());
+			Assert.AreEqual("1, 2, 3, 4", string.Join(", ", groups.First()));
+		}
+
+		[Test]
+		public void Can_Get_Empty_List_In_Groups_Of_Four()
+		{
+			var items = new List<string>();
+			var groups = items.InGroupsOf(4);
+			Assert.AreEqual(0, groups.Count());
+		}
+
+		[Test]
+		public void Can_Get_Fieldsets_In_Groups_Of_Two()
+		{
+			var sampleJson = File.ReadAllText("..\\..\\Data\\sample-1.json");
+			var converter = new ArchetypeValueConverter();
+			var result = (Archetype.Models.ArchetypeModel)converter.ConvertDataToSource(null, sampleJson, false);
+
+			Assert.AreEqual(2, result.Fieldsets.Count());
+			var groups = result.Fieldsets.InGroupsOf(2);
+			Assert.AreEqual(1, groups.Count());
+			Assert.IsTrue(groups.First().First() == result.Fieldsets.First());
+			Assert.IsTrue(groups.First().Last() == result.Fieldsets.Last());
+		}
+
+		[Test]
+		public void Can_Get_Properties_In_Groups_Of_Two()
+		{
+			var sampleJson = File.ReadAllText("..\\..\\Data\\sample-1.json");
+			var converter = new ArchetypeValueConverter();
+			var result = (Archetype.Models.ArchetypeModel)converter.ConvertDataToSource(null, sampleJson, false);
+			var properties = result.Fieldsets.First().Properties.ToList();
+
+			Assert.AreEqual(4, properties.Count());
+			var groups = properties.InGroupsOf(2);
+			Assert.AreEqual(2, groups.Count());
+
+			Assert.AreEqual(properties[0], groups.First().First());
+			Assert.AreEqual(properties[1], groups.First().Last());
+			Assert.AreEqual(properties[2], groups.Last().First());
+			Assert.AreEqual(properties[3], groups.Last().Last());
+		}
+	}
+}

--- a/app/Umbraco/Umbraco.Archetype/Archetype.Umbraco.csproj
+++ b/app/Umbraco/Umbraco.Archetype/Archetype.Umbraco.csproj
@@ -232,6 +232,7 @@
     <Compile Include="Constants.cs" />
     <Compile Include="Events\ExpireCache.cs" />
     <Compile Include="Extensions\ArchetypeHelper.cs" />
+    <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="Extensions\HtmlHelperExtensions.cs" />
     <Compile Include="Extensions\ArchetypePropertyModelExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />

--- a/app/Umbraco/Umbraco.Archetype/Extensions/EnumerableExtensions.cs
+++ b/app/Umbraco/Umbraco.Archetype/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Archetype.Extensions
+{
+	public static class EnumerableExtensions
+	{
+		public static IEnumerable<IEnumerable<T>> InGroupsOf<T>(this IEnumerable<T> items, int numberOfItemsPerGroup)
+		{
+			return items.Select((e, i) => new { Item = e, Grouping = (i / numberOfItemsPerGroup) })
+				.GroupBy(e => e.Grouping)
+				.Select(g => g.Select(x => x.Item));
+		}
+	}
+}


### PR DESCRIPTION
This PR adds `EnumerableExtensions` to the `Archetype.Extensions` namespace in order to support `InGroupsOf` on any `IEnumerable<T>`. Thus, if adding the namespace `Archetype.Extensions` to a view, one can use `InGroupsOf` on `Fieldsets`, `Properties` and whatnot - e.g. `myArchetype.Fieldsets.InGroupsOf(2)` or `myArchetype.Fieldsets.First().Properties.InGroupsOf(2)`
