### PR TITLE
Bug fix with the Courier resolver

### DIFF
--- a/app/Umbraco/Archetype.Courier/DataResolvers/ArchetypeDataResolver.cs
+++ b/app/Umbraco/Archetype.Courier/DataResolvers/ArchetypeDataResolver.cs
@@ -86,7 +86,7 @@ namespace Archetype.Courier.DataResolvers
 				if (archetype != null)
 				{
 					// create a 'fake' provider, as ultimately only the 'Packaging' enum will be referenced.
-					var fakeItemProvider = new PropertyItemProvider();
+					var fakeItemProvider = new PropertyItemProvider() { ExecutionContext = this.ExecutionContext };
 
 					foreach (var property in archetype.Fieldsets.SelectMany(x => x.Properties))
 					{


### PR DESCRIPTION
Turns out there was an issue with the latest Courier build... the fake providers were missing the "execution context".

@kgiszewski - let me know if the PRs for the Courier resolver are a pain, I'm happy to commit directly, but just felt like PRs were the "way to go" :-)
