### PR TITLE
Pass data type guid for property editors (specifically Vorto)

### DIFF
--- a/app/directives/archetypeproperty.js
+++ b/app/directives/archetypeproperty.js
@@ -82,7 +82,7 @@ angular.module("umbraco.directives").directive('archetypeProperty', function ($c
 
                 var mergedConfig = _.extend(defaultConfigObj, config);
 
-                loadView(pathToView, mergedConfig, defaultValue, alias, propertyAlias, scope, element, ngModelCtrl, propertyValueChanged);
+                loadView(pathToView, mergedConfig, defaultValue, alias, propertyAlias, dataTypeGuid, scope, element, ngModelCtrl, propertyValueChanged);
             });
         });
 
@@ -158,7 +158,7 @@ angular.module("umbraco.directives").directive('archetypeProperty', function ($c
         return _.unique(propertyAliasParts).reverse().join("-");
     };
 
-    function loadView(view, config, defaultValue, alias, propertyAlias, scope, element, ngModelCtrl, propertyValueChanged) {
+    function loadView(view, config, defaultValue, alias, propertyAlias, dataTypeGuid, scope, element, ngModelCtrl, propertyValueChanged) {
         if (view)
         {
             $http.get(view, { cache: true }).success(function (data) {
@@ -200,6 +200,9 @@ angular.module("umbraco.directives").directive('archetypeProperty', function ($c
                             scope.model.config.multiPicker = "0";
                         }
                     }
+
+                    //Vorto data type guid
+                    scope.model.dataTypeGuid = dataTypeGuid;
 
                     //console.log(scope.model.config);
 


### PR DESCRIPTION
This PR will require also another PR in Vorto to make it wok so it's just a first step. It is not a very nice solution because it creates a dependency between these two packages (archetype passes guid which vorto then must use instead of it's default - polling the server). To make it more general, it would be nice to update umbraco core to include more data type info (like the guid) in Umbraco.Web.Models.ContentEditing.ContentPropertyBasic (which gets passed to $scope.model for every property editor) and then to update Vorto to read guid from this. This PR for archetype would then just imitate default umbraco behaviour. But that's another story and this can be a first step :). So as I don't have time to dive into umbraco core yet, this is just something like a quick and little dirty fix...