### PR TITLE
Remove caching for property datatype dropdowns

### DIFF
--- a/app/resources/propertyeditor.js
+++ b/app/resources/propertyeditor.js
@@ -3,7 +3,7 @@ angular.module('umbraco.resources').factory('archetypePropertyEditorResource', f
         getAllDataTypes: function() {
             // Hack - grab DataTypes from Tree API, as `dataTypeService.getAll()` isn't implemented yet
             return umbRequestHelper.resourcePromise(
-                $http.get("/umbraco/backoffice/ArchetypeApi/ArchetypeDataType/GetAll", { cache: true }), 'Failed to retrieve datatypes from tree service'
+                $http.get("/umbraco/backoffice/ArchetypeApi/ArchetypeDataType/GetAll"), 'Failed to retrieve datatypes from tree service'
             );
         },
         getDataType: function (guid, useDeepDatatypeLookup, contentTypeAlias, propertyTypeAlias, archetypeAlias, nodeId) {


### PR DESCRIPTION
The caching here seems to cause some confusion (#241, #207).  If you've added a new datatype, it won't show in Archetype's datatype dropdown until a hard-refresh, yet it does in Umbraco's.

Since this method is only used in the "backend" (ie, the Developer/Datatype section and not the Archetype UI), I think it's probably OK not to cache it.