### PR TITLE
Updates the Courier provider

### DIFF
--- a/app/Umbraco/Umbraco.Archetype/Extensions/ArchetypeHelper.cs
+++ b/app/Umbraco/Umbraco.Archetype/Extensions/ArchetypeHelper.cs
@@ -26,6 +26,8 @@ namespace Archetype.Extensions
             _app = ApplicationContext.Current;
         }
 
+        internal JsonSerializerSettings JsonSerializerSettings { get { return _jsonSettings; } }
+
         internal ArchetypeModel DeserializeJsonToArchetype(string sourceJson, PreValueCollection dataTypePreValues)
         {
             try

--- a/app/Umbraco/Umbraco.Archetype/PropertyEditors/ArcheTypePropertyEditor.cs
+++ b/app/Umbraco/Umbraco.Archetype/PropertyEditors/ArcheTypePropertyEditor.cs
@@ -66,6 +66,7 @@ namespace Archetype.PropertyEditors
 					{
                         try
                         {
+                            if(propDef == null || propDef.DataTypeGuid == null) continue;
                             var dtd = ArchetypeHelper.Instance.GetDataTypeByGuid(Guid.Parse(propDef.DataTypeGuid));
 						    var propType = new PropertyType(dtd) { Alias = propDef.Alias };
 						    var prop = new Property(propType, propDef.Value);


### PR DESCRIPTION
This updates the Courier provider to not rely on the PropertyEditorValueConverter, which was causing problems during extraction.

The Courier provider was refactored to use the json serialization/deserialization for the existing Archetype models, and to only use Courier for lookups related to existing Umbraco data like DocumentTypes, DataTypes, etc.

