### PR TITLE
Fix #261

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,6 +55,7 @@ module.exports = function(grunt) {
           'app/controllers/controller.js',
           'app/controllers/config.controller.js',
           'app/directives/archetypeproperty.js',
+          'app/directives/archetypesubmitwatcher.js',
           'app/directives/archetypecustomview.js',
           'app/directives/localize.js',
           'app/services/localization.js',

--- a/app/controllers/controller.js
+++ b/app/controllers/controller.js
@@ -299,6 +299,8 @@
                 $scope.model.value.toString = stringify;
             }
         }
+        // reset submit watcher counter on save
+        $scope.activeSubmitWatcher = 0;
     });
 
     //helper to count what is visible
@@ -397,5 +399,18 @@
     if($scope.model.config.customCssPath)
     {
         assetsService.loadCss($scope.model.config.customCssPath);
+    }
+
+    // submit watcher handling:
+    // because some property editors use the "formSubmitting" event to set/clean up their model.value,
+    // we need to monitor the "formSubmitting" event from a custom property and broadcast our own event
+    // to forcefully update the appropriate model.value's
+    $scope.activeSubmitWatcher = 0;
+    $scope.submitWatcherOnLoad = function () {
+        $scope.activeSubmitWatcher++;
+        return $scope.activeSubmitWatcher;
+    }
+    $scope.submitWatcherOnSubmit = function () {
+        $scope.$broadcast("archetypeFormSubmitting");
     }
 });

--- a/app/directives/archetypesubmitwatcher.js
+++ b/app/directives/archetypesubmitwatcher.js
@@ -1,0 +1,24 @@
+angular.module("umbraco.directives").directive('archetypeSubmitWatcher', function ($rootScope) {
+    var linker = function (scope, element, attrs, ngModelCtrl) {
+        // call the load callback on scope to obtain the ID of this submit watcher
+        var id = scope.loadCallback();
+        scope.$on("formSubmitting", function (ev, args) {
+            // on the "formSubmitting" event, call the submit callback on scope to notify the Archetype controller to do it's magic
+            if (id == scope.activeSubmitWatcher) {
+                scope.submitCallback();
+            }
+        });
+    }
+
+    return {
+        restrict: "E",
+        replace: true,
+        link: linker,
+        template: "",
+        scope: {
+            loadCallback: '=',
+            submitCallback: '=',
+            activeSubmitWatcher: '='
+        }
+    }
+});

--- a/app/views/archetype.default.html
+++ b/app/views/archetype.default.html
@@ -40,6 +40,7 @@
 
                             <div ng-class="[(model.config.hidePropertyLabels == '1' ? 'controls-no-label' : 'controls')]">
                                 <archetype-property class="archetypeEditor" property="property" property-editor-alias="model.alias" fieldset-index="$parent.$index" fieldset="fieldset" archetype-config="model.config" property-config-index="$index" archetype-render-model="model.value" umbraco-form="form"></archetype-property>
+                                <archetype-submit-watcher active-submit-watcher="activeSubmitWatcher" load-callback="submitWatcherOnLoad" submit-callback="submitWatcherOnSubmit"></archetype-submit-watcher>
                             </div>
                         </div>
                     </form>


### PR DESCRIPTION
The ```formSubmitting``` event handlers are called synchronously, and apparently in the order which they were subscribed to the event. By adding an event handler to the ```formSubmitting``` event for each property added to a fieldset (after the property itself has been added), we can make sure that Archetype gets "the last say" in the ```formSubmitting``` event handler chain. This allows us to broadcast our own event ```archetypeFormSubmitting``` to all the Archetype properties, so they in turn can update their ```model.value``` if need be, before the entire Archetype is submitted.

**PLEASE NOTE**
I am submitting this only halfway tested - some family stuff is going to keep me busy for a while, so I thought I'd submit it now for someone else to test, rather than sit on it until I could complete testing it myself. 
Off the top of my head I can think of a few things that need to be tested:
* Validation - specially for mandatory member pickers, but also validation in general.
* Multiple Archetypes on one content type - is the new event isolated to each Archetype, because it will be broadcast for each of the.
* Nested Archetypes (same potential issue as in the last point).
