### PR TITLE
PropertyEditorAlias null check

### DIFF
--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypePropertyModel.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypePropertyModel.cs
@@ -34,7 +34,7 @@ namespace Archetype.Models
 
             // Try Umbraco's PropertyValueConverters
             var converters = UmbracoContext.Current != null ? PropertyValueConvertersResolver.Current.Converters : Enumerable.Empty<IPropertyValueConverter>();
-            if (converters.Any())
+            if (!string.IsNullOrWhiteSpace(this.PropertyEditorAlias) && converters.Any())
             {
                 var convertedAttempt = TryConvertWithPropertyValueConverters<T>(Value, converters);
                 if (convertedAttempt.Success)


### PR DESCRIPTION
Don't call`PropertyValueConverters` for properties with null or empty
`PropertyEditorAlias`, prevents `System.NullReferenceException`  in
`PropertyValueConverter.IsConverter` implementations.