### PR TITLE
Changed the way tags are stripped from tinymce content

### DIFF
--- a/app/services/archetypeLabelService.js
+++ b/app/services/archetypeLabelService.js
@@ -140,7 +140,7 @@ angular.module('umbraco.services').factory('archetypeLabelService', function (ar
         }
 
         var suffix = "";
-        var strippedText = $(value).text();
+        var strippedText = $("<div/>").html(value).text();
 
         if(strippedText.length > args.contentLength) {
         	suffix = "…";


### PR DESCRIPTION
See stackoverflow for a reference: http://stackoverflow.com/questions/13140043/how-to-strip-html-tags-with-jquery
The old version gave me a lot of errors since a text without tags was treated as a css selector