### PR TITLE
Remove editorState from model before persisting

### DIFF
--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypeModel.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypeModel.cs
@@ -30,15 +30,9 @@ namespace Archetype.Models
 
         public string SerializeForPersistence()
         {
-            // clear the editor state before serializing (it's temporary state data)
-            foreach(var property in Fieldsets.SelectMany(f => f.Properties.Where(p => p.EditorState != null)).ToList())
-            {
-                property.EditorState = null;
-            }
-
             var json = JObject.Parse(JsonConvert.SerializeObject(this, new JsonSerializerSettings() { ReferenceLoopHandling = ReferenceLoopHandling.Ignore }));
 
-            var propertiesToRemove = new String[] { "propertyEditorAlias", "dataTypeId", "dataTypeGuid", "hostContentType" };
+            var propertiesToRemove = new String[] { "propertyEditorAlias", "dataTypeId", "dataTypeGuid", "hostContentType", "editorState" };
 
             json.Descendants().OfType<JProperty>()
               .Where(p => propertiesToRemove.Contains(p.Name))


### PR DESCRIPTION
In #281 an `EditorState` property was added to `ArchetypePropertyModel`.  I noticed this was leaking into my published data, I was seeing this in the `umbraco.config`:

```json
{
  "fieldsets": [
    {
      "properties": [
        {
          "alias": "file",
          "value": "/media/4981/123_123.zip",
          "editorState": null
        },
       ...
```

We already have a mechanism for removing some similar properties that are only for the UI, so to fix this I added `editorState` to that list.

Also, stoked that upload fields are working now, nice work! :clap: