### PR TITLE
ArchetypeModel to IPublishedContent

### DIFF
--- a/app/Umbraco/Archetype.Tests/Archetype.Tests.csproj
+++ b/app/Umbraco/Archetype.Tests/Archetype.Tests.csproj
@@ -261,6 +261,7 @@
     <Compile Include="Models\FieldsetTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PropertyValueConverter\PropertyValueConverterTests.cs" />
+    <Compile Include="PublishedContent\ArchetypePublishedContentTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/app/Umbraco/Archetype.Tests/PublishedContent/ArchetypePublishedContentTests.cs
+++ b/app/Umbraco/Archetype.Tests/PublishedContent/ArchetypePublishedContentTests.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Linq;
+using Archetype.Extensions;
+using Archetype.Models;
+using Archetype.PropertyConverters;
+using NUnit.Framework;
+using Umbraco.Core.Models;
+using Umbraco.Web;
+
+namespace Archetype.Tests.PublishedContent
+{
+    [TestFixture]
+    public class ArchetypePublishedContentTests
+    {
+        private ArchetypeModel _archetype;
+
+        [TestFixtureSetUp]
+        public void Init()
+        {
+            var archetypeJson = System.IO.File.ReadAllText("..\\..\\Data\\sample-1.json");
+            var converter = new ArchetypeValueConverter();
+
+            _archetype = (ArchetypeModel)converter.ConvertDataToSource(null, archetypeJson, false);
+        }
+
+        [Test]
+        public void ArchetypeModel_Initialized()
+        {
+            Assert.IsNotNull(_archetype);
+            Assert.IsNotEmpty(_archetype.Fieldsets);
+        }
+
+        [Test]
+        public void ArchetypeModel_To_PublishedContentSet()
+        {
+            var contentSet = _archetype.ToPublishedContentSet();
+
+            Assert.That(contentSet, Is.Not.Null);
+            Assert.That(contentSet, Is.Not.Empty);
+            Assert.That(contentSet, Is.All.InstanceOf<IPublishedContent>());
+        }
+
+        [Test]
+        public void ArchetypeFieldsetModel_To_PublishedContent()
+        {
+            var fieldset = _archetype.Fieldsets.FirstOrDefault();
+            var content = fieldset.ToPublishedContent();
+
+            Assert.That(content, Is.Not.Null);
+            Assert.That(content, Is.InstanceOf<IPublishedContent>());
+            Assert.That(content.Properties, Is.Not.Empty);
+            Assert.That(content.Properties, Is.All.InstanceOf<IPublishedProperty>());
+        }
+
+        [TestCase("boxHeadline", "Box 1 Title")]
+        [TestCase("link", "3175")]
+        [TestCase("link", 3175)]
+        [TestCase("show", "1")]
+        [TestCase("show", true)]
+        [TestCase("show", 1)]
+        public void ArchetypePublishedContent_Typed_Properties<T>(string propertyAlias, T expected)
+        {
+            var fieldset = _archetype.Fieldsets.FirstOrDefault();
+            var content = fieldset.ToPublishedContent();
+
+            var actual = content.GetPropertyValue<T>(propertyAlias);
+
+            Assert.AreEqual(actual, expected);
+        }
+
+        [Test]
+        public void Null_ArchetypeModel_Throws_Exception()
+        {
+            TestDelegate code = () =>
+            {
+                ArchetypeModel archetype = null;
+                archetype.ToPublishedContentSet();
+            };
+
+            Assert.Throws<ArgumentNullException>(code);
+        }
+
+        [Test]
+        public void Null_ArchetypeFieldsetModel_Throws_Exception()
+        {
+            TestDelegate code = () =>
+            {
+                ArchetypeFieldsetModel fieldset = null;
+                fieldset.ToPublishedContent();
+            };
+
+            Assert.Throws<ArgumentNullException>(code);
+        }
+    }
+}

--- a/app/Umbraco/Umbraco.Archetype/Archetype.Umbraco.csproj
+++ b/app/Umbraco/Umbraco.Archetype/Archetype.Umbraco.csproj
@@ -231,7 +231,9 @@
     <Compile Include="Api\ArchetypeDataTypeController.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="Events\ExpireCache.cs" />
+    <Compile Include="Extensions\ArchetypeFieldsetModelExtensions.cs" />
     <Compile Include="Extensions\ArchetypeHelper.cs" />
+    <Compile Include="Extensions\ArchetypeModelExtensions.cs" />
     <Compile Include="Extensions\HtmlHelperExtensions.cs" />
     <Compile Include="Extensions\ArchetypePropertyModelExtensions.cs" />
     <Compile Include="Extensions\PropertyEditorExtensions.cs" />
@@ -243,6 +245,9 @@
     <Compile Include="Models\ArchetypePreValueProperty.cs" />
     <Compile Include="Models\ArchetypeFieldsetModel.cs" />
     <Compile Include="Models\ArchetypePropertyModel.cs" />
+    <Compile Include="Models\ArchetypePublishedContent.cs" />
+    <Compile Include="Models\ArchetypePublishedContentSet.cs" />
+    <Compile Include="Models\ArchetypePublishedProperty.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\VersionInfo.cs" />
     <Compile Include="PropertyConverters\ArchetypeValueConverter.cs" />

--- a/app/Umbraco/Umbraco.Archetype/Extensions/ArchetypeFieldsetModelExtensions.cs
+++ b/app/Umbraco/Umbraco.Archetype/Extensions/ArchetypeFieldsetModelExtensions.cs
@@ -1,0 +1,13 @@
+﻿using Archetype.Models;
+using Umbraco.Core.Models;
+
+namespace Archetype.Extensions
+{
+    public static class ArchetypeFieldsetModelExtensions
+    {
+        public static IPublishedContent ToPublishedContent(this ArchetypeFieldsetModel fieldset)
+        {
+            return new ArchetypePublishedContent(fieldset);
+        }
+    }
+}

--- a/app/Umbraco/Umbraco.Archetype/Extensions/ArchetypeModelExtensions.cs
+++ b/app/Umbraco/Umbraco.Archetype/Extensions/ArchetypeModelExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using Archetype.Models;
+using Umbraco.Core.Models;
+
+namespace Archetype.Extensions
+{
+    public static class ArchetypeModelExtensions
+    {
+        public static IEnumerable<IPublishedContent> ToPublishedContentSet(this ArchetypeModel archetype)
+        {
+            return new ArchetypePublishedContentSet(archetype);
+        }
+    }
+}

--- a/app/Umbraco/Umbraco.Archetype/Extensions/ArchetypePropertyModelExtensions.cs
+++ b/app/Umbraco/Umbraco.Archetype/Extensions/ArchetypePropertyModelExtensions.cs
@@ -2,6 +2,7 @@ using Archetype.Models;
 using Umbraco.Core;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Core.PropertyEditors;
 
 namespace Archetype.Extensions
 {
@@ -27,6 +28,11 @@ namespace Archetype.Extensions
         /// <returns></returns>
         internal static PublishedPropertyType CreateDummyPropertyType(this ArchetypePropertyModel prop)
         {
+            // We need to check if `PropertyValueConvertersResolver` exists,
+            // otherwise `PublishedPropertyType` will throw an exception outside of the Umbraco context.; e.g. unit-tests.
+            if (!PropertyValueConvertersResolver.HasCurrent)
+                return null;
+
             return new PublishedPropertyType(prop.HostContentType, new PropertyType(new DataTypeDefinition(-1, prop.PropertyEditorAlias) { Id = prop.DataTypeId }));
         }
     }

--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypePublishedContent.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypePublishedContent.cs
@@ -11,9 +11,7 @@ namespace Archetype.Models
     {
         private ArchetypeFieldsetModel _fieldset;
 
-        private bool _initialized;
-
-        private IPublishedProperty[] _properties;
+        private readonly Dictionary<string, IPublishedProperty> _properties;
 
         public ArchetypePublishedContent(ArchetypeFieldsetModel fieldset)
         {
@@ -22,7 +20,11 @@ namespace Archetype.Models
 
             _fieldset = fieldset;
 
-            this.Initialize();
+            _properties = fieldset.Properties
+                .ToDictionary(
+                    x => x.Alias,
+                    x => new ArchetypePublishedProperty(x) as IPublishedProperty,
+                    StringComparer.InvariantCultureIgnoreCase);
         }
 
         internal ArchetypeFieldsetModel ArchetypeFieldset
@@ -77,7 +79,8 @@ namespace Archetype.Models
 
         public IPublishedProperty GetProperty(string alias, bool recurse)
         {
-            return Properties.FirstOrDefault(x => x.PropertyTypeAlias.InvariantEquals(alias));
+            IPublishedProperty property;
+            return _properties.TryGetValue(alias, out property) ? property : null;
         }
 
         public IPublishedProperty GetProperty(string alias)
@@ -122,15 +125,7 @@ namespace Archetype.Models
 
         public ICollection<IPublishedProperty> Properties
         {
-            get
-            {
-                if (_initialized == false)
-                {
-                    this.Initialize();
-                }
-
-                return _properties;
-            }
+            get { return _properties.Values; }
         }
 
         public int SortOrder
@@ -183,24 +178,6 @@ namespace Archetype.Models
                     ? null
                     : property.Value;
             }
-        }
-
-        private void Initialize()
-        {
-            if (_fieldset == null)
-            {
-                return;
-            }
-
-            if (_fieldset.Properties != null)
-            {
-                _properties = _fieldset.Properties
-                    .Select(x => new ArchetypePublishedProperty(x))
-                    .Cast<IPublishedProperty>()
-                    .ToArray();
-            }
-
-            _initialized = true;
         }
     }
 }

--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypePublishedContent.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypePublishedContent.cs
@@ -1,0 +1,206 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Core;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.PublishedContent;
+
+namespace Archetype.Models
+{
+    public class ArchetypePublishedContent : IPublishedContent
+    {
+        private ArchetypeFieldsetModel _fieldset;
+
+        private bool _initialized;
+
+        private IPublishedProperty[] _properties;
+
+        public ArchetypePublishedContent(ArchetypeFieldsetModel fieldset)
+        {
+            if (fieldset == null)
+                throw new ArgumentNullException("fieldset");
+
+            _fieldset = fieldset;
+
+            this.Initialize();
+        }
+
+        internal ArchetypeFieldsetModel ArchetypeFieldset
+        {
+            get { return _fieldset; }
+        }
+
+        public IEnumerable<IPublishedContent> Children
+        {
+            get { return Enumerable.Empty<IPublishedContent>(); }
+        }
+
+        public IEnumerable<IPublishedContent> ContentSet
+        {
+            get { return Enumerable.Empty<IPublishedContent>(); }
+        }
+
+        public PublishedContentType ContentType
+        {
+            get { return default(PublishedContentType); }
+        }
+
+        public DateTime CreateDate
+        {
+            get { return DateTime.MinValue; }
+        }
+
+        public int CreatorId
+        {
+            get { return default(int); }
+        }
+
+        public string CreatorName
+        {
+            get { return default(string); }
+        }
+
+        public string DocumentTypeAlias
+        {
+            get { return _fieldset.Alias; }
+        }
+
+        public int DocumentTypeId
+        {
+            get { return default(int); }
+        }
+
+        public int GetIndex()
+        {
+            return default(int);
+        }
+
+        public IPublishedProperty GetProperty(string alias, bool recurse)
+        {
+            return Properties.FirstOrDefault(x => x.PropertyTypeAlias.InvariantEquals(alias));
+        }
+
+        public IPublishedProperty GetProperty(string alias)
+        {
+            return this.GetProperty(alias, false);
+        }
+
+        public int Id
+        {
+            get { return default(int); }
+        }
+
+        public bool IsDraft
+        {
+            get { return _fieldset.Disabled; }
+        }
+
+        public PublishedItemType ItemType
+        {
+            get { return PublishedItemType.Content; }
+        }
+
+        public int Level
+        {
+            get { return default(int); }
+        }
+
+        public string Name
+        {
+            get { return default(string); }
+        }
+
+        public IPublishedContent Parent
+        {
+            get { return default(IPublishedContent); }
+        }
+
+        public string Path
+        {
+            get { return default(string); }
+        }
+
+        public ICollection<IPublishedProperty> Properties
+        {
+            get
+            {
+                if (_initialized == false)
+                {
+                    this.Initialize();
+                }
+
+                return _properties;
+            }
+        }
+
+        public int SortOrder
+        {
+            get { return default(int); }
+        }
+
+        public int TemplateId
+        {
+            get { return default(int); }
+        }
+
+        public DateTime UpdateDate
+        {
+            get { return default(DateTime); }
+        }
+
+        public string Url
+        {
+            get { return default(string); }
+        }
+
+        public string UrlName
+        {
+            get { return default(string); }
+        }
+
+        public Guid Version
+        {
+            get { return Guid.Empty; }
+        }
+
+        public int WriterId
+        {
+            get { return default(int); }
+        }
+
+        public string WriterName
+        {
+            get { return default(string); }
+        }
+
+        public object this[string alias]
+        {
+            get
+            {
+                var property = this.GetProperty(alias);
+
+                return property == null
+                    ? null
+                    : property.Value;
+            }
+        }
+
+        private void Initialize()
+        {
+            if (_fieldset == null)
+            {
+                return;
+            }
+
+            if (_fieldset.Properties != null)
+            {
+                _properties = _fieldset.Properties
+                    .Select(x => new ArchetypePublishedProperty(x))
+                    .Cast<IPublishedProperty>()
+                    .ToArray();
+            }
+
+            _initialized = true;
+        }
+    }
+}

--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypePublishedContentSet.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypePublishedContentSet.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Archetype.Models
+{
+    public class ArchetypePublishedContentSet : IEnumerable<ArchetypePublishedContent>
+    {
+        private IEnumerable<ArchetypePublishedContent> _items { get; set; }
+
+        public ArchetypePublishedContentSet(ArchetypeModel archetype)
+        {
+            if (archetype == null)
+                throw new ArgumentNullException("archetype");
+
+            this.ArchetypeModel = archetype;
+
+            _items = archetype.Fieldsets
+                .Where(x => x.Disabled == false)
+                .Select(x => new ArchetypePublishedContent(x));
+        }
+
+        internal ArchetypeModel ArchetypeModel { get; private set; }
+
+        public IEnumerator<ArchetypePublishedContent> GetEnumerator()
+        {
+            return _items.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+}

--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypePublishedProperty.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypePublishedProperty.cs
@@ -53,30 +53,13 @@ namespace Archetype.Models
         {
             get
             {
-                if (_property == null || _rawValue == null)
-                {
-                    return false;
-                }
-
-                return !string.IsNullOrEmpty(_rawValue.ToString());
+                return _rawValue != null && !string.IsNullOrEmpty(_rawValue.ToString());
             }
         }
 
         public string PropertyTypeAlias
         {
-            get
-            {
-                if (_propertyType != null && !string.IsNullOrWhiteSpace(_propertyType.PropertyTypeAlias))
-                {
-                    return _propertyType.PropertyTypeAlias;
-                }
-                else if (_property != null)
-                {
-                    return _property.Alias;
-                }
-
-                return null;
-            }
+            get { return _property.Alias; }
         }
 
         public object Value

--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypePublishedProperty.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypePublishedProperty.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using Archetype.Extensions;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.PublishedContent;
+
+namespace Archetype.Models
+{
+    public class ArchetypePublishedProperty : IPublishedProperty
+    {
+        private readonly object _rawValue;
+        private readonly Lazy<object> _sourceValue;
+        private readonly Lazy<object> _objectValue;
+        private readonly Lazy<object> _xpathValue;
+        private readonly ArchetypePropertyModel _property;
+        private readonly PublishedPropertyType _propertyType;
+
+        public ArchetypePublishedProperty(ArchetypePropertyModel property)
+        {
+            if (property == null)
+                throw new ArgumentNullException("property");
+
+            var preview = false;
+
+            _property = property;
+            _rawValue = property.Value;
+
+            _propertyType = property.CreateDummyPropertyType();
+
+            if (_propertyType != null)
+            {
+                _sourceValue = new Lazy<object>(() => _propertyType.ConvertDataToSource(_rawValue, preview));
+                _objectValue = new Lazy<object>(() => _propertyType.ConvertSourceToObject(_sourceValue.Value, preview));
+                _xpathValue = new Lazy<object>(() => _propertyType.ConvertSourceToXPath(_sourceValue.Value, preview));
+            }
+        }
+
+        internal ArchetypePropertyModel ArchetypeProperty
+        {
+            get { return _property; }
+        }
+
+        public object DataValue
+        {
+            get
+            {
+                return _sourceValue != null
+                    ? _sourceValue.Value
+                    : _rawValue;
+            }
+        }
+
+        public bool HasValue
+        {
+            get
+            {
+                if (_property == null || _rawValue == null)
+                {
+                    return false;
+                }
+
+                return !string.IsNullOrEmpty(_rawValue.ToString());
+            }
+        }
+
+        public string PropertyTypeAlias
+        {
+            get
+            {
+                if (_propertyType != null && !string.IsNullOrWhiteSpace(_propertyType.PropertyTypeAlias))
+                {
+                    return _propertyType.PropertyTypeAlias;
+                }
+                else if (_property != null)
+                {
+                    return _property.Alias;
+                }
+
+                return null;
+            }
+        }
+
+        public object Value
+        {
+            get
+            {
+                return _objectValue != null
+                    ? _objectValue.Value
+                    : _rawValue;
+            }
+        }
+
+        public object XPathValue
+        {
+            get
+            {
+                return _xpathValue != null
+                    ? _xpathValue.Value
+                    : _rawValue;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds extension methods for `ArchetypeModel` and `ArchetypeFieldsetModel` for converting to Umbraco's `IPublishedContent`.

Included unit-tests to support the deserialization and verify property-value retrieval.

Modifies `ArchetypePropertyModelExtensions.CreateDummyPropertyType` extension method, to test if the `PropertyValueConvertersResolver` is available, (otherwise the unit-tests throw an exception from Umbraco's `PublishedPropertyType`).