### PR TITLE
Correct for attribute to match id of input

### DIFF
--- a/app/controllers/controller.js
+++ b/app/controllers/controller.js
@@ -15,6 +15,8 @@ angular.module("umbraco").controller("Imulus.ArchetypeController", function ($sc
 
     // store the umbraco property alias to help generate unique IDs.  Hopefully there's a better way to get this in the future :)
     $scope.umbracoHostPropertyAlias = $scope.$parent.$parent.model.alias;
+    
+    $scope.isDebuggingEnabled = Umbraco.Sys.ServerVariables.isDebuggingEnabled;
 
     $scope.overlayMenu = {
         show: false,

--- a/app/views/archetype.default.html
+++ b/app/views/archetype.default.html
@@ -24,7 +24,7 @@
                 <div class="archetypeCollapser animate-hide" ng-hide="model.config.enableCollapsing && isCollapsed(fieldset)" ng-if="!isCollapsed(fieldset)">
                     <form class="form-inline">
                         <div ng-class="[('archetype-property-' + property.alias), (getPropertyValidity($parent.$index, property.alias) === false ? 'archetypePropertyError' : '')]" class="archetypeProperty control-group" ng-repeat="property in fieldsetConfigModel.properties">
-                            <label ng-hide="model.config.hidePropertyLabels == '1'" class="control-label" for="archetype-property-{{model.alias}}-{{$parent.$index}}-{{$index}}">
+                            <label ng-hide="model.config.hidePropertyLabels == '1'" class="control-label" for="archetype-property-{{model.alias}}-f{{$parent.$index}}-{{property.alias}}-p{{$index}}" ng-attr-title="{{ isDebuggingEnabled || model.config.developerMode ? property.alias : null }}">
                                 <span>{{property.label}}</span>
                                 <div class="archetypeFieldsetHelpText" ng-show="property.helpText">
                                     <small>{{property.helpText}}</small>


### PR DESCRIPTION
... futhermore add title tooltip with value of property alias like in
Umbraco core.

Fixes issue #313 

Archetype is re-using the core property editors and it seems the label doesn't set focus for some properties like numeric, decimal, datepicker and maybe others because of mismatch between value of for-attribute and id-attribute. Furthermore it is important they include the property alias in those values so it set focus on the right input field: http://issues.umbraco.org/issue/U4-7648