### PR TITLE
Added support to ArchetypePublishedContent for Umbraco extension methods

### DIFF
--- a/app/Umbraco/Archetype.Tests/PublishedContent/ArchetypePublishedContentTests.cs
+++ b/app/Umbraco/Archetype.Tests/PublishedContent/ArchetypePublishedContentTests.cs
@@ -91,5 +91,66 @@ namespace Archetype.Tests.PublishedContent
 
             Assert.Throws<ArgumentNullException>(code);
         }
+
+        [Test]
+        public void ArchetypePublishedContent_GetIndex()
+        {
+            var contentSet = _archetype.ToPublishedContentSet();
+            var i = 0;
+
+            foreach (var content in contentSet)
+            {
+                Assert.AreEqual(content.GetIndex(), i);
+                i++;
+            }
+        }
+
+        [Test]
+        public void ArchetypePublishedContentSet_IsFirstIsLast()
+        {
+            var contentSet = _archetype.ToPublishedContentSet();
+
+            foreach (var content in contentSet)
+            {
+                var value = content.GetPropertyValue<string>("boxHeadline");
+
+                Assert.That(value == "Box 1 Title", Is.EqualTo(content.IsFirst()));
+                Assert.That(value == "Another Box", Is.EqualTo(content.IsLast()));
+            }
+        }
+
+        [Test]
+        public void ArchetypePublishedContentSet_PreviousNext()
+        {
+            var contentSet = _archetype.ToPublishedContentSet();
+            var list = contentSet.ToList();
+
+            Assert.That(list.Count, Is.EqualTo(2));
+
+            var first = list[0];
+            var last = list[1];
+
+            var next = first.Next();
+            Assert.AreEqual(next, last);
+
+            var prev = last.Previous();
+            Assert.AreEqual(prev, first);
+        }
+
+        [Test, ExpectedException(typeof(NullReferenceException))]
+        public void ArchetypePublishedContentSet_Siblings()
+        {
+            var contentSet = _archetype.ToPublishedContentSet();
+            var content = contentSet.FirstOrDefault();
+
+            var siblings = content.Siblings();
+            Assert.That(siblings, Is.Not.Null);
+
+            var following = content.FollowingSibling();
+            Assert.That(following, Is.Not.Null);
+
+            var preceding = content.PrecedingSibling();
+            Assert.That(preceding, Is.Not.Null);
+        }
     }
 }

--- a/app/Umbraco/Umbraco.Archetype/Extensions/ArchetypeFieldsetModelExtensions.cs
+++ b/app/Umbraco/Umbraco.Archetype/Extensions/ArchetypeFieldsetModelExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Archetype.Models;
+﻿using System.Linq;
+using Archetype.Models;
 using Umbraco.Core.Models;
 
 namespace Archetype.Extensions
@@ -8,6 +9,17 @@ namespace Archetype.Extensions
         public static IPublishedContent ToPublishedContent(this ArchetypeFieldsetModel fieldset)
         {
             return new ArchetypePublishedContent(fieldset);
+        }
+
+        public static IPublishedContent ToPublishedContent(this ArchetypeFieldsetModel fieldset, ArchetypeModel archetype)
+        {
+            var contentSet = archetype.ToPublishedContentSet();
+
+            var first = contentSet
+                .Cast<ArchetypePublishedContent>()
+                .FirstOrDefault(x => x.ArchetypeFieldset == fieldset);
+
+            return first ?? new ArchetypePublishedContent(fieldset);
         }
     }
 }

--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypePublishedContent.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypePublishedContent.cs
@@ -11,14 +11,17 @@ namespace Archetype.Models
     {
         private ArchetypeFieldsetModel _fieldset;
 
+        private IEnumerable<IPublishedContent> _parent;
+
         private readonly Dictionary<string, IPublishedProperty> _properties;
 
-        public ArchetypePublishedContent(ArchetypeFieldsetModel fieldset)
+        public ArchetypePublishedContent(ArchetypeFieldsetModel fieldset, ArchetypePublishedContentSet parent = null)
         {
             if (fieldset == null)
                 throw new ArgumentNullException("fieldset");
 
             _fieldset = fieldset;
+            _parent = parent ?? Enumerable.Empty<IPublishedContent>();
 
             _properties = fieldset.Properties
                 .ToDictionary(
@@ -39,7 +42,7 @@ namespace Archetype.Models
 
         public IEnumerable<IPublishedContent> ContentSet
         {
-            get { return Enumerable.Empty<IPublishedContent>(); }
+            get { return _parent; }
         }
 
         public PublishedContentType ContentType
@@ -74,7 +77,7 @@ namespace Archetype.Models
 
         public int GetIndex()
         {
-            return default(int);
+            return _parent.IndexOf(this);
         }
 
         public IPublishedProperty GetProperty(string alias, bool recurse)

--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypePublishedContentSet.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypePublishedContentSet.cs
@@ -16,9 +16,12 @@ namespace Archetype.Models
 
             this.ArchetypeModel = archetype;
 
+            var count = archetype.Fieldsets.Count();
+
             _items = archetype.Fieldsets
                 .Where(x => x.Disabled == false)
-                .Select(x => new ArchetypePublishedContent(x));
+                .Select(x => new ArchetypePublishedContent(x, this))
+                .ToArray();
         }
 
         internal ArchetypeModel ArchetypeModel { get; private set; }


### PR DESCRIPTION
For the `IPublishedContent` implementation, added support for `GetIndex()`, so that extension methods, such as `IsFirst()`, `IsLast()`, etc will work as expected.

Unfortunately we wont be able to support the `Siblings()`, (or `FollowingSibling`, `PrecedingSibling`) extension methods, as these perform an internal query to the node's parent's children - which in the context of Archetype data is not possible access.

Added unit-tests to support this enhancement.

Resolves #329