### PR TITLE
Support publish and unpublish

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -125,7 +125,7 @@ module.exports = function(grunt) {
         expand: true
       },
       dll: {
-        cwd: 'app/Umbraco/Umbraco.Archetype/bin/Debug/',
+        cwd: 'app/Umbraco/Umbraco.Archetype/bin/Release/',
         src: 'Archetype.dll',
         dest: '<%= dest %>/bin/',
         expand: true

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -125,7 +125,7 @@ module.exports = function(grunt) {
         expand: true
       },
       dll: {
-        cwd: 'app/Umbraco/Umbraco.Archetype/bin/Release/',
+        cwd: 'app/Umbraco/Umbraco.Archetype/bin/Debug/',
         src: 'Archetype.dll',
         dest: '<%= dest %>/bin/',
         expand: true

--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypeFieldsetModel.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypeFieldsetModel.cs
@@ -23,6 +23,12 @@ namespace Archetype.Models
         [JsonProperty("id")]
         public Guid Id { get; set; }
 
+		[JsonProperty("releaseDate")]
+		public DateTime? ReleaseDate { get; set; }
+
+		[JsonProperty("expireDate")]
+		public DateTime? ExpireDate { get; set; }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ArchetypeFieldsetModel"/> class.
         /// </summary>

--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypeFieldsetModel.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypeFieldsetModel.cs
@@ -142,8 +142,8 @@ namespace Archetype.Models
 	    internal bool IsDisabled()
 	    {
 		    return Disabled
-		           || (ReleaseDate.HasValue && ReleaseDate > DateTime.Now)
-		           || (ExpireDate.HasValue && DateTime.Now > ExpireDate);
+		           || (ReleaseDate.HasValue && ReleaseDate > DateTime.UtcNow)
+				   || (ExpireDate.HasValue && DateTime.UtcNow > ExpireDate);
 	    }
 
         #endregion

--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypeFieldsetModel.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypeFieldsetModel.cs
@@ -23,11 +23,11 @@ namespace Archetype.Models
         [JsonProperty("id")]
         public Guid Id { get; set; }
 
-		[JsonProperty("releaseDate")]
-		public DateTime? ReleaseDate { get; set; }
+        [JsonProperty("releaseDate")]
+        public DateTime? ReleaseDate { get; set; }
 
-		[JsonProperty("expireDate")]
-		public DateTime? ExpireDate { get; set; }
+        [JsonProperty("expireDate")]
+        public DateTime? ExpireDate { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ArchetypeFieldsetModel"/> class.
@@ -135,16 +135,16 @@ namespace Archetype.Models
             return Properties.FirstOrDefault(p => p.Alias.InvariantEquals(propertyAlias));
         }
 
-		/// <summary>
-		/// Is this fieldset disabled, either explicitly or by other means?
-		/// </summary>
-		/// <returns>true if this fieldset is disabled, false otherwise</returns>
-	    internal bool IsDisabled()
-	    {
-		    return Disabled
-		           || (ReleaseDate.HasValue && ReleaseDate > DateTime.UtcNow)
-				   || (ExpireDate.HasValue && DateTime.UtcNow > ExpireDate);
-	    }
+        /// <summary>
+        /// Is this fieldset disabled, either explicitly or by other means?
+        /// </summary>
+        /// <returns>true if this fieldset is disabled, false otherwise</returns>
+        internal bool IsDisabled()
+        {
+            return Disabled
+                   || (ReleaseDate.HasValue && ReleaseDate > DateTime.UtcNow)
+                   || (ExpireDate.HasValue && DateTime.UtcNow > ExpireDate);
+        }
 
         #endregion
     }

--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypeFieldsetModel.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypeFieldsetModel.cs
@@ -135,6 +135,17 @@ namespace Archetype.Models
             return Properties.FirstOrDefault(p => p.Alias.InvariantEquals(propertyAlias));
         }
 
+		/// <summary>
+		/// Is this fieldset disabled, either explicitly or by other means?
+		/// </summary>
+		/// <returns>true if this fieldset is disabled, false otherwise</returns>
+	    internal bool IsDisabled()
+	    {
+		    return Disabled
+		           || (ReleaseDate.HasValue && ReleaseDate > DateTime.Now)
+		           || (ExpireDate.HasValue && DateTime.Now > ExpireDate);
+	    }
+
         #endregion
     }
 }

--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypeModel.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypeModel.cs
@@ -32,7 +32,7 @@ namespace Archetype.Models
         /// </returns>
         public IEnumerator<ArchetypeFieldsetModel> GetEnumerator()
         {
-            return this.Fieldsets.Where(f => f.Disabled == false).GetEnumerator();
+            return this.Fieldsets.Where(f => f.IsDisabled() == false).GetEnumerator();
         }
 
         //possibly obsolete?

--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypePreValue.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypePreValue.cs
@@ -31,6 +31,9 @@ namespace Archetype.Models
         [JsonProperty("enableDisabling")]
         public bool EnableDisabling { get; set; }
 
+		[JsonProperty("enablePublishing")]
+		public bool EnablePublishing { get; set; }
+
         [JsonProperty("hideFieldsetControls")]
         public bool HideFieldsetControls { get; set; }
 

--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypePreValue.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypePreValue.cs
@@ -31,8 +31,8 @@ namespace Archetype.Models
         [JsonProperty("enableDisabling")]
         public bool EnableDisabling { get; set; }
 
-		[JsonProperty("enablePublishing")]
-		public bool EnablePublishing { get; set; }
+        [JsonProperty("enablePublishing")]
+        public bool EnablePublishing { get; set; }
 
         [JsonProperty("hideFieldsetControls")]
         public bool HideFieldsetControls { get; set; }

--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypePublishedContent.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypePublishedContent.cs
@@ -98,7 +98,7 @@ namespace Archetype.Models
 
         public bool IsDraft
         {
-            get { return _fieldset.Disabled; }
+            get { return _fieldset.IsDisabled(); }
         }
 
         public PublishedItemType ItemType

--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypePublishedContentSet.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypePublishedContentSet.cs
@@ -19,7 +19,7 @@ namespace Archetype.Models
             var count = archetype.Fieldsets.Count();
 
             _items = archetype.Fieldsets
-                .Where(x => x.Disabled == false)
+                .Where(x => x.IsDisabled() == false)
                 .Select(x => new ArchetypePublishedContent(x, this))
                 .ToArray();
         }

--- a/app/Umbraco/Umbraco.Archetype/PropertyEditors/ArcheTypePropertyEditor.cs
+++ b/app/Umbraco/Umbraco.Archetype/PropertyEditors/ArcheTypePropertyEditor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Archetype.Extensions;
+using Archetype.Models;
 using ClientDependency.Core;
 using Newtonsoft.Json;
 using Umbraco.Core;
@@ -175,6 +176,10 @@ namespace Archetype.PropertyEditors
 				var uploadedFiles = editorValue.AdditionalData.ContainsKey("files") ? editorValue.AdditionalData["files"] as IEnumerable<ContentItemFile> : null;
 				foreach (var fieldset in archetype.Fieldsets)
 				{
+					// make sure the publishing dates are in UTC
+					fieldset.ReleaseDate = EnsureUtcDate(fieldset.ReleaseDate);
+					fieldset.ExpireDate = EnsureUtcDate(fieldset.ExpireDate);
+
 					// assign an id to the fieldset if it has none (e.g. newly created fieldset)
 					fieldset.Id = fieldset.Id == Guid.Empty ? Guid.NewGuid() : fieldset.Id;
 					// find the corresponding fieldset in the current Archetype value (if any)
@@ -236,6 +241,20 @@ namespace Archetype.PropertyEditors
 				return dtd.PropertyEditorAlias.Equals(Constants.PropertyEditorAlias)
 					? new ArchetypePropertyEditor()
 					: (PropertyEditor) new TextboxPropertyEditor();
+			}
+
+			/// <summary>
+			/// Ensures that a datetime is in UTC
+			/// </summary>
+			/// <param name="dateTime">The datetime</param>
+			/// <returns>The datetime in UTC (or null if it's not set)</returns>
+			private DateTime? EnsureUtcDate(DateTime? dateTime)
+			{
+				if(dateTime.HasValue == false || dateTime.Value.Kind == DateTimeKind.Utc)
+				{
+					return dateTime;
+				}
+				return new DateTime(dateTime.Value.Ticks, DateTimeKind.Utc);
 			}
 		}
 

--- a/app/controllers/controller.js
+++ b/app/controllers/controller.js
@@ -284,8 +284,6 @@ angular.module("umbraco").controller("Imulus.ArchetypeController", function ($sc
         if (fieldset.expireDateModel && fieldset.expireDateModel.value) {
             // an expired release affects the fieldset
             return moment() > moment(fieldset.expireDateModel.value);
-            // this fieldset is either expired or will expire - both cases affects the fieldset
-            //return true;
         }
         if (fieldset.releaseDateModel && fieldset.releaseDateModel.value) {
             // a pending release affects the fieldset

--- a/app/controllers/controller.js
+++ b/app/controllers/controller.js
@@ -265,40 +265,15 @@ angular.module("umbraco").controller("Imulus.ArchetypeController", function ($sc
         if ($scope.canPublish() == false) {
             return false;
         }
-        // disabled state takes precedence over publishing
-        if (fieldset.disabled) {
-            return false;
+        if ($scope.canDisable()) {
+            // disabled state takes precedence over publishing
+            if (fieldset.disabled) {
+                return false;
+            }
+            return $scope.isDisabledByPublishing(fieldset);
         }
-        return $scope.isDisabledByPublishing(fieldset);
+        return true;
     }
-
-    //$scope.isDisabled = function(fieldset) {
-    //    if (fieldset.disabled) {
-    //        return true;
-    //    }
-    //    return $scope.isDisabledByPublishing(fieldset);
-    //}
-
-    //$scope.disabledIcon = function(fieldset) {
-    //    if ($scope.isDisabledByPublishing(fieldset)) {
-    //        return "icon-time";
-    //    }
-    //    return "icon-power";
-    //}
-
-    //$scope.hasPublishingPending = function (fieldset) {
-    //    if ($scope.canPublish() === false) {
-    //        return false;
-    //    }
-    //    if (fieldset.expireDateModel && fieldset.expireDateModel.value) {
-    //        // pending expiry?
-    //        return moment(fieldset.expireDateModel.value) > moment();
-    //    }
-    //    if (fieldset.releaseDateModel && fieldset.releaseDateModel.value) {
-    //        // pending release?
-    //        return moment(fieldset.releaseDateModel.value) > moment();
-    //    }
-    //}
 
     $scope.isDisabledByPublishing = function (fieldset) {
         if ($scope.canPublish() === false) {
@@ -321,17 +296,7 @@ angular.module("umbraco").controller("Imulus.ArchetypeController", function ($sc
         if (fieldset.disabled) {
             return true;
         }
-        if ($scope.canPublish() === false) {
-            return false;
-        }
-        if (fieldset.expireDateModel && fieldset.expireDateModel.value) {
-            // expired?
-            return moment() > moment(fieldset.expireDateModel.value);
-        }
-        if (fieldset.releaseDateModel && fieldset.releaseDateModel.value) {
-            // pending release?
-            return moment(fieldset.releaseDateModel.value) > moment();
-        }
+        return $scope.isDisabledByPublishing(fieldset);
     }
 
     //helper, ini the render model from the server (model.value)

--- a/app/controllers/controller.js
+++ b/app/controllers/controller.js
@@ -442,6 +442,7 @@ angular.module("umbraco").controller("Imulus.ArchetypeController", function ($sc
         // reset submit watcher counter on save
         $scope.activeSubmitWatcher = 0;
 
+        // create properties needed for the backoffice to work (data that is not serialized to DB)
         addCustomProperties();
     });
 

--- a/app/controllers/controller.js
+++ b/app/controllers/controller.js
@@ -589,7 +589,6 @@ angular.module("umbraco").controller("Imulus.ArchetypeController", function ($sc
             fieldset.releaseDate = fieldset.releaseDateModel.value;
             fieldset.expireDate = fieldset.expireDateModel.value;
         });
-        console.log("submitWatcherOnSubmit", $scope.model.value.fieldsets);
         $scope.$broadcast("archetypeFormSubmitting");
     }
 });

--- a/app/controllers/controller.js
+++ b/app/controllers/controller.js
@@ -148,6 +148,8 @@ angular.module("umbraco").controller("Imulus.ArchetypeController", function ($sc
                 }
             }
 
+            addCustomPropertiesToFieldset(newFieldset);
+
             $scope.setDirty();
 
             $scope.$broadcast("archetypeAddFieldset", {index: $index, visible: countVisible()});
@@ -316,18 +318,22 @@ angular.module("umbraco").controller("Imulus.ArchetypeController", function ($sc
 
     function addCustomProperties() {
         _.each($scope.model.value.fieldsets, function (fieldset) {
-            // create models for publish configuration
-            fieldset.releaseDateModel = {
-                alias: _.uniqueId("archetypeReleaseDate_"),
-                view: "datepicker",
-                value: fieldset.releaseDate
-            };
-            fieldset.expireDateModel = {
-                alias: _.uniqueId("archetypeExpireDate_"),
-                view: "datepicker",
-                value: fieldset.expireDate
-            };
+            addCustomPropertiesToFieldset(fieldset);
         });
+    }
+
+    function addCustomPropertiesToFieldset(fieldset) {
+        // create models for publish configuration
+        fieldset.releaseDateModel = {
+            alias: _.uniqueId("archetypeReleaseDate_"),
+            view: "datepicker",
+            value: fieldset.releaseDate
+        };
+        fieldset.expireDateModel = {
+            alias: _.uniqueId("archetypeExpireDate_"),
+            view: "datepicker",
+            value: fieldset.expireDate
+        };
     }
 
     //helper to get the correct fieldset from config

--- a/app/controllers/controller.js
+++ b/app/controllers/controller.js
@@ -304,20 +304,20 @@ angular.module("umbraco").controller("Imulus.ArchetypeController", function ($sc
     //helper, ini the render model from the server (model.value)
     function init() {
         $scope.model.value = removeNulls($scope.model.value);
-        addDefaultProperties();
+        addDefaultProperties($scope.model.value.fieldsets);
     }
 
-    function addDefaultProperties()
+    function addDefaultProperties(fieldsets)
     {
-        _.each($scope.model.value.fieldsets, function (fieldset)
+        _.each(fieldsets, function (fieldset)
         {
             fieldset.collapse = false;
             fieldset.isValid = true;
         });
     }
 
-    function addCustomProperties() {
-        _.each($scope.model.value.fieldsets, function (fieldset) {
+    function addCustomProperties(fieldsets) {
+        _.each(fieldsets, function (fieldset) {
             addCustomPropertiesToFieldset(fieldset);
         });
     }
@@ -447,7 +447,7 @@ angular.module("umbraco").controller("Imulus.ArchetypeController", function ($sc
         $scope.activeSubmitWatcher = 0;
 
         // create properties needed for the backoffice to work (data that is not serialized to DB)
-        addCustomProperties();
+        addCustomProperties($scope.model.value.fieldsets);
     });
 
     //helper to count what is visible

--- a/app/langs/da-dk.js
+++ b/app/langs/da-dk.js
@@ -44,5 +44,9 @@
   "fieldsetGroups":"Fieldset-grupper",
   "fieldsetGroupsDescription":"Hvis du har mange fieldsets, skal du måske overveje at gruppere dem i fieldset-vælgeren. Når du først har defineret dine grupper her, vil en gruppe-vælger dukke op i fieldset-editoren, og du kan derefter vælge grupper for alle dine fieldsets.",
   "fieldsetGroupName":"Navn",
-  "addFieldsetGroup":"Tilføj gruppe"
+  "addFieldsetGroup":"Tilføj gruppe",
+  "publish": "Publicering",
+  "publishHelpText": "Konfigurér udgivelses- og udløbsdato for dette element",
+  "publishReleaseDate": "Udgivelsesdato",
+  "publishExpireDate": "Udløbsdato"
 }

--- a/app/langs/da-dk.js
+++ b/app/langs/da-dk.js
@@ -45,8 +45,11 @@
   "fieldsetGroupsDescription":"Hvis du har mange fieldsets, skal du måske overveje at gruppere dem i fieldset-vælgeren. Når du først har defineret dine grupper her, vil en gruppe-vælger dukke op i fieldset-editoren, og du kan derefter vælge grupper for alle dine fieldsets.",
   "fieldsetGroupName":"Navn",
   "addFieldsetGroup":"Tilføj gruppe",
+  "enablePublishing": "Aktivér fieldset-publicering?",
+  "enablePublishingDescription": "Tillad automatisk udgivelse og udløb for fieldsets",
   "publish": "Publicering",
   "publishHelpText": "Konfigurér udgivelses- og udløbsdato for dette element",
   "publishReleaseDate": "Udgivelsesdato",
-  "publishExpireDate": "Udløbsdato"
+  "publishExpireDate": "Udløbsdato",
+  "settings": "Indstillinger"
 }

--- a/app/langs/da.js
+++ b/app/langs/da.js
@@ -44,5 +44,12 @@
   "fieldsetGroups":"Fieldset-grupper",
   "fieldsetGroupsDescription":"Hvis du har mange fieldsets, skal du måske overveje at gruppere dem i fieldset-vælgeren. Når du først har defineret dine grupper her, vil en gruppe-vælger dukke op i fieldset-editoren, og du kan derefter vælge grupper for alle dine fieldsets.",
   "fieldsetGroupName":"Navn",
-  "addFieldsetGroup":"Tilføj gruppe"    
+  "addFieldsetGroup":"Tilføj gruppe",
+  "enablePublishing": "Aktivér fieldset-publicering?",
+  "enablePublishingDescription": "Tillad automatisk udgivelse og udløb for fieldsets",
+  "publish": "Publicering",
+  "publishHelpText": "Konfigurér udgivelses- og udløbsdato for dette element",
+  "publishReleaseDate": "Udgivelsesdato",
+  "publishExpireDate": "Udløbsdato",
+  "settings": "Indstillinger"
 }

--- a/app/less/archetype.less
+++ b/app/less/archetype.less
@@ -64,6 +64,17 @@
         vertical-align: text-bottom;
     }
 
+    .caret {
+        margin: 8px 1px 0 2px;
+        &.caret-right {
+            border-bottom: 4px solid transparent;
+            border-top: 4px solid transparent;
+            border-left: 4px solid #ddd;
+            content: "";
+            margin-top: 6px;
+        }
+    }
+
     fieldset {
         border-bottom: 1px dashed #dddddd;
         padding: 0;
@@ -152,16 +163,7 @@
             }
 
             .caret {
-                margin: 8px 1px 0 2px;
                 position: absolute;
-
-                &.caret-right {
-                    border-bottom: 4px solid transparent;
-                    border-top: 4px solid transparent;
-                    border-left: 4px solid #ddd;
-                    content: "";
-                    margin-top: 6px;
-                }
             }
 
             label {
@@ -307,6 +309,30 @@
                     text-decoration: none;
                 }
             }
+        }
+    }
+
+    .settingsWrapper {
+        &:hover {
+            caret {
+                background-color: #333;
+            }
+        }
+        .settingsHeader {
+            &:hover {
+                cursor: pointer;
+                label {
+                    text-decoration: underline;
+                }
+
+                .caret-right {
+                    border-left-color: #333;
+                }
+            }
+        }
+        .settings {
+            padding: 14px;
+            background-color: #f8f8f8;
         }
     }
 }

--- a/app/less/archetype.less
+++ b/app/less/archetype.less
@@ -43,6 +43,18 @@
         &.icon-delete:hover {
             color: #b94a48;
         }
+        &.icon-disabled {
+            cursor: default;
+            &:hover {
+                color: #ddd;
+            }
+        }
+        &.icon-active {
+            color: #333;
+            &:hover {
+                color: #333;
+            }
+        }
     }
 
     .fieldsetIcon {
@@ -75,6 +87,19 @@
                     color: #d9d9d9;
                 }
 
+            }
+            
+            .publishOptions {
+                .publishDate {
+                    display: inline-block;
+                    vertical-align: top;
+                    margin-right: 20px;
+                    
+                    label {
+                        padding: 0 !important;
+                        margin: 0 !important;
+                    }
+                }
             }
         }
 

--- a/app/views/archetype.config.fieldset.dialog.html
+++ b/app/views/archetype.config.fieldset.dialog.html
@@ -27,6 +27,9 @@
         <div>
             <label for="archetypeAdvancedOptionsDisabling"><input type="checkbox" id="archetypeAdvancedOptionsDisabling" ng-model="model.enableDisabling" /><archetype-localize key="enableDisabling">Enable Fieldset Disabling?</archetype-localize><small><archetype-localize key="enableDisablingDescription">Allows fieldsets to be individually enabled/disabled.</archetype-localize></small></label>
         </div>
+        <div>
+            <label for="archetypeAdvancedOptionsPublishing"><input type="checkbox" id="archetypeAdvancedOptionsPublishing" ng-model="model.enablePublishing" /><archetype-localize key="enablePublishing">Enable Fieldset Publishing?</archetype-localize><small><archetype-localize key="enablePublishingDescription">Allows fieldsets to be automatically published and/or unpublished.</archetype-localize></small></label>
+        </div>
         
         <h4><archetype-localize key="multipleFieldsets">Multiple fieldsets</archetype-localize></h4>
         <div>

--- a/app/views/archetype.default.html
+++ b/app/views/archetype.default.html
@@ -8,7 +8,7 @@
                     <div ng-click="focusFieldset(fieldset)" class="label-sub module-label">
                         <span class="caret" ng-hide="fieldset.collapse || !model.config.enableCollapsing"></span>
                         <span class="caret caret-right" ng-show="fieldset.collapse && model.config.enableCollapsing"></span>
-                        <label ng-class="{dimmed: fieldset.disabled}">
+                        <label ng-class="{dimmed: isDisabled(fieldset)}">
                             <i class="fieldsetIcon icon ng-class:fieldsetConfigModel.icon"></i>
                             <span ng-bind="getFieldsetTitle(fieldsetConfigModel, $index)"></span>
                         </label>
@@ -17,7 +17,8 @@
                         <i class="icon icon-add" ng-show="canAdd()" ng-click="openFieldsetPicker($index, $event)"></i>
                         <i class="icon icon-navigation handle" ng-show="canSort()"></i>
                         <i class="icon icon-documents" ng-click="cloneRow($index)" ng-show="canClone()"></i>
-                        <i class="icon icon-power" ng-click="enableDisable(fieldset)" ng-show="canDisable()"></i>
+                        <i class="icon icon-power" ng-class="{'icon-active': fieldset.disabled}" ng-click="enableDisable(fieldset)" ng-show="showDisableIcon(fieldset)"></i>
+                        <i class="icon icon-time icon-disabled" ng-class="{'icon-active': isDisabledByPublishing(fieldset)}" ng-show="showPublishingIcon(fieldset)"></i>
                         <i class="icon icon-delete" ng-click="removeRow($index)" ng-show="canRemove()"></i>
                     </div>
                 </div>
@@ -34,6 +35,32 @@
                             <div ng-class="[(model.config.hidePropertyLabels == '1' ? 'controls-no-label' : 'controls')]">
                                 <archetype-property class="archetypeEditor" property="property" property-editor-alias="model.alias" fieldset-index="$parent.$index" fieldset="fieldset" archetype-config="model.config" property-config-index="$index" archetype-render-model="model.value" umbraco-form="form"></archetype-property>
                                 <archetype-submit-watcher active-submit-watcher="activeSubmitWatcher" load-callback="submitWatcherOnLoad" submit-callback="submitWatcherOnSubmit"></archetype-submit-watcher>
+                            </div>
+                        </div>
+                        <div class="archetypeProperty control-group" ng-show="canConfigure()">
+                            <!-- misc fieldset configuration goes below this line -->
+                            <hr />
+                            <div ng-show="canPublish()">
+                                <label ng-hide="model.config.hidePropertyLabels == '1'" class="control-label">
+                                    <span><archetype-localize key="publish">Publishing</archetype-localize></span>
+                                    <div class="archetypeFieldsetHelpText">
+                                        <small><archetype-localize key="publishHelpText">Configure automatic publishing and/or unpublishing of this item</archetype-localize></small>
+                                    </div>
+                                </label>
+                                <div class="publishOptions" ng-class="[(model.config.hidePropertyLabels == '1' ? 'controls-no-label' : 'controls')]">
+                                    <div class="publishDate">
+                                        <label for="{{fieldset.releaseDateModel.alias}}">
+                                            <archetype-localize key="publishReleaseDate">Publish at</archetype-localize>
+                                        </label>
+                                        <umb-editor model="fieldset.releaseDateModel"></umb-editor>
+                                    </div>
+                                    <div class="publishDate">
+                                        <label for="{{fieldset.expireDateModel.alias}}">
+                                            <archetype-localize key="publishExpireDate">Unpublish at</archetype-localize>
+                                        </label>
+                                        <umb-editor model="fieldset.expireDateModel"></umb-editor>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     </form>

--- a/app/views/archetype.default.html
+++ b/app/views/archetype.default.html
@@ -37,28 +37,36 @@
                                 <archetype-submit-watcher active-submit-watcher="activeSubmitWatcher" load-callback="submitWatcherOnLoad" submit-callback="submitWatcherOnSubmit"></archetype-submit-watcher>
                             </div>
                         </div>
-                        <div class="archetypeProperty control-group" ng-show="canConfigure()">
-                            <!-- misc fieldset configuration goes below this line -->
-                            <hr />
-                            <div ng-show="canPublish()">
-                                <label ng-hide="model.config.hidePropertyLabels == '1'" class="control-label">
-                                    <span><archetype-localize key="publish">Publishing</archetype-localize></span>
-                                    <div class="archetypeFieldsetHelpText">
-                                        <small><archetype-localize key="publishHelpText">Configure automatic publishing and/or unpublishing of this item</archetype-localize></small>
-                                    </div>
+                        <div class="control-group archetypeProperty settingsWrapper" ng-show="canConfigure()">
+                            <div ng-click="showSettings = !showSettings" class="settingsHeader">
+                                <span class="caret" ng-show="showSettings"></span>
+                                <span class="caret caret-right" ng-hide="showSettings"></span>
+                                <label>
+                                    <span><archetype-localize key="settings">Settings</archetype-localize></span>
                                 </label>
-                                <div class="publishOptions" ng-class="[(model.config.hidePropertyLabels == '1' ? 'controls-no-label' : 'controls')]">
-                                    <div class="publishDate">
-                                        <label for="{{fieldset.releaseDateModel.alias}}">
-                                            <archetype-localize key="publishReleaseDate">Publish at</archetype-localize>
-                                        </label>
-                                        <umb-editor model="fieldset.releaseDateModel"></umb-editor>
-                                    </div>
-                                    <div class="publishDate">
-                                        <label for="{{fieldset.expireDateModel.alias}}">
-                                            <archetype-localize key="publishExpireDate">Unpublish at</archetype-localize>
-                                        </label>
-                                        <umb-editor model="fieldset.expireDateModel"></umb-editor>
+                            </div>
+                            <div class="settings" ng-show="showSettings">
+                                <!-- misc fieldset settings go here -->
+                                <div ng-show="canPublish()">
+                                    <label ng-hide="model.config.hidePropertyLabels == '1'" class="control-label">
+                                        <span><archetype-localize key="publish">Publishing</archetype-localize></span>
+                                        <div class="archetypeFieldsetHelpText">
+                                            <small><archetype-localize key="publishHelpText">Configure automatic publishing and/or unpublishing of this item</archetype-localize></small>
+                                        </div>
+                                    </label>
+                                    <div class="publishOptions" ng-class="[(model.config.hidePropertyLabels == '1' ? 'controls-no-label' : 'controls')]">
+                                        <div class="publishDate">
+                                            <label for="{{fieldset.releaseDateModel.alias}}">
+                                                <archetype-localize key="publishReleaseDate">Publish at</archetype-localize>
+                                            </label>
+                                            <umb-editor model="fieldset.releaseDateModel"></umb-editor>
+                                        </div>
+                                        <div class="publishDate">
+                                            <label for="{{fieldset.expireDateModel.alias}}">
+                                                <archetype-localize key="publishExpireDate">Unpublish at</archetype-localize>
+                                            </label>
+                                            <umb-editor model="fieldset.expireDateModel"></umb-editor>
+                                        </div>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Fixes #334 

**Please note:** Unlike Umbraco's built-in publish and unpublish for content types, this implementation uses UTC to determine when a fieldset should be published or unpublished. Although that's a deviation from the Umbraco way of doing things, I fear we'll get flooded with support issues if we don't use UTC.

![archetype-publish-6](https://cloud.githubusercontent.com/assets/7405322/13978837/60a0d70c-f0d4-11e5-847a-4c150c3ed713.png)
