### PR TITLE
Fix issue #326

### DIFF
--- a/app/directives/archetypeproperty.js
+++ b/app/directives/archetypeproperty.js
@@ -93,9 +93,11 @@ angular.module("umbraco.directives").directive('archetypeProperty', function ($c
                         }
                     }
 
-                    //upload, colorpicker datatype hack
-                    if(view.indexOf('fileupload.html') != -1 || view.indexOf('colorpicker.html') != -1) {
+                    //hacks for various built-in datatyps including upload, colorpicker and tags
+                    if (!scope.propertyForm) {
                         scope.propertyForm = scope.form;
+                    }
+                    if (!scope.model.validation) {
                         scope.model.validation = {};
                         scope.model.validation.mandatory = 0;
                     }


### PR DESCRIPTION
This PR solves issue #326. 

By reusing the existing hacks for the color picker and upload datatypes, we can support tags and probably also other (built-in or custom) datatypes.

NOTE: This only adds support for tags stored in JSON. 

Issue #232 is probably also solved with this PR.