### PR TITLE
Fix issue #342

### DIFF
--- a/app/controllers/config.controller.js
+++ b/app/controllers/config.controller.js
@@ -313,9 +313,13 @@ angular.module("umbraco").controller("Imulus.ArchetypeConfigController", functio
         dialogService.open({
             template: template,
             show: true,
-            callback: function(data) {
+            callback: function (data) {
+                // replace the entire render model if it was changed (in developer options)
+                if (data.model && data.modelChanged) {
+                    $scope.archetypeConfigRenderModel = data.model;
+                }
             },
-            dialogData: $scope.archetypeConfigRenderModel
+            dialogData: { model: $scope.archetypeConfigRenderModel }
         });
     }
 

--- a/app/controllers/config.dialog.controller.js
+++ b/app/controllers/config.dialog.controller.js
@@ -1,17 +1,15 @@
 angular.module('umbraco').controller('ArchetypeConfigOptionsController', function ($scope) {
-    $scope.model = $scope.dialogData;
-
     //handles a fieldset group add
     $scope.addFieldsetGroup = function () {
-        $scope.model.fieldsetGroups.push({ name: "" });
+        $scope.dialogData.model.fieldsetGroups.push({ name: "" });
     }
 
     //handles a fieldset group removal
     $scope.removeFieldsetGroup = function ($index) {
-        $scope.model.fieldsetGroups.splice($index, 1);
+        $scope.dialogData.model.fieldsetGroups.splice($index, 1);
     }
 
     $scope.apply = function(index) {
-        $scope.submit($scope.model);
+        $scope.submit($scope.dialogData);
     }
 });

--- a/app/views/archetype.config.developer.dialog.html
+++ b/app/views/archetype.config.developer.dialog.html
@@ -3,18 +3,18 @@
     <div class="umb-panel-body no-header with-footer umb-scrollable archetypeAdvancedOptions">
         <h3><archetype-localize key="developer_options">Developer Options</archetype-localize></h3>
         <div>
-            <label for="archetypeAdvancedOptionsDeepDatatypeRequest"><input type="checkbox" id="archetypeAdvancedOptionsDeepDatatypeRequest" ng-model="model.enableDeepDatatypeRequests"/><archetype-localize key="deepDatatypeRequest">Enable Deep Datatype Requests?</archetype-localize><small><archetype-localize key="deepDatatypeRequestDescription">Allows for easier datatype interception at the cost of caching performance.</archetype-localize></small></label>
+            <label for="archetypeAdvancedOptionsDeepDatatypeRequest"><input type="checkbox" id="archetypeAdvancedOptionsDeepDatatypeRequest" ng-model="dialogData.model.enableDeepDatatypeRequests" /><archetype-localize key="deepDatatypeRequest">Enable Deep Datatype Requests?</archetype-localize><small><archetype-localize key="deepDatatypeRequestDescription">Allows for easier datatype interception at the cost of caching performance.</archetype-localize></small></label>
         </div>
         <div>
-            <label for="archetypeAdvancedOptionsDeveloperMode"><input type="checkbox" id="archetypeAdvancedOptionsDeveloperMode" ng-model="model.developerMode"/><archetype-localize key="toggleDeveloperMode">Enable Developer Mode?</archetype-localize><small><archetype-localize key="toggleDeveloperModeDescription">Toggle Developer Mode</archetype-localize></small></label>
+            <label for="archetypeAdvancedOptionsDeveloperMode"><input type="checkbox" id="archetypeAdvancedOptionsDeveloperMode" ng-model="dialogData.model.developerMode" /><archetype-localize key="toggleDeveloperMode">Enable Developer Mode?</archetype-localize><small><archetype-localize key="toggleDeveloperModeDescription">Toggle Developer Mode</archetype-localize></small></label>
         </div>
         <div>
-            <label for="archetypeOverrideDefaultConverter"><input type="checkbox" id="archetypeOverrideDefaultConverter" ng-model="model.overrideDefaultPropertyValueConverter" /><archetype-localize key="overrideDefaultConverter">Override Default Property Value Converter?</archetype-localize><small><archetype-localize key="overrideDefaultConverterDescription">Check this if you wish to use your own custom property value converter.</archetype-localize></small></label>
+            <label for="archetypeOverrideDefaultConverter"><input type="checkbox" id="archetypeOverrideDefaultConverter" ng-model="dialogData.model.overrideDefaultPropertyValueConverter" /><archetype-localize key="overrideDefaultConverter">Override Default Property Value Converter?</archetype-localize><small><archetype-localize key="overrideDefaultConverterDescription">Check this if you wish to use your own custom property value converter.</archetype-localize></small></label>
         </div>
 
         <div>
             <label for="archetypeAdvancedOptionsConfigModel"><archetype-localize key="configModel">Config Model</archetype-localize><small><archetype-localize key="configModelDescription">Be careful editing the text below, it controls the schema for this archetype.</archetype-localize></small></label>
-            <textarea class="archetypeDeveloperModel" id="archetypeAdvancedOptionsConfigModel" ng-model="model"></textarea>
+            <textarea class="archetypeDeveloperModel" id="archetypeAdvancedOptionsConfigModel" ng-model="dialogData.model" ng-change="dialogData.modelChanged = true"></textarea>
         </div>
     </div>
     <div class="umb-panel-footer">

--- a/app/views/archetype.config.fieldset.dialog.html
+++ b/app/views/archetype.config.fieldset.dialog.html
@@ -3,46 +3,46 @@
     <div class="umb-panel-body no-header with-footer umb-scrollable archetypeAdvancedOptions">
         <h3><archetype-localize key="global_fieldset_options">Global Fieldset Options</archetype-localize></h3>
         <div>
-            <label for="archetypeAdvancedOptionsStartWithAddButton"><input type="checkbox" id="archetypeAdvancedOptionsStartWithAddButton" ng-model="model.startWithAddButton"/><archetype-localize key="startWithAddButton">Start With Add Button?</archetype-localize><small><archetype-localize key="startWithAddButtonDescription">Empty property shows an add button instead of providing a default fieldset.</archetype-localize></small></label>
+            <label for="archetypeAdvancedOptionsStartWithAddButton"><input type="checkbox" id="archetypeAdvancedOptionsStartWithAddButton" ng-model="dialogData.model.startWithAddButton"/><archetype-localize key="startWithAddButton">Start With Add Button?</archetype-localize><small><archetype-localize key="startWithAddButtonDescription">Empty property shows an add button instead of providing a default fieldset.</archetype-localize></small></label>
         </div>
         <div>
-            <label for="archetypeAdvancedOptionsHideLabels"><input type="checkbox" id="archetypeAdvancedOptionsHideLabels" ng-model="model.hidePropertyLabels"/><archetype-localize key="hidePropertyLabels">Hide Property Labels?</archetype-localize><small><archetype-localize key="hidePropertyLabelsDescription">Hides the property labels.</archetype-localize></small></label>       
+            <label for="archetypeAdvancedOptionsHideLabels"><input type="checkbox" id="archetypeAdvancedOptionsHideLabels" ng-model="dialogData.model.hidePropertyLabels"/><archetype-localize key="hidePropertyLabels">Hide Property Labels?</archetype-localize><small><archetype-localize key="hidePropertyLabelsDescription">Hides the property labels.</archetype-localize></small></label>       
         </div>
         <div>
-            <label for="archetypeAdvancedOptionsCollapsing"><input type="checkbox" id="archetypeAdvancedOptionsCollapsing" ng-model="model.enableCollapsing"/><archetype-localize key="enableCollapsing">Enable Collapsing?</archetype-localize><small><archetype-localize key="enableCollapsingDescription">Enable fieldset collapsing.</archetype-localize></small></label>
+            <label for="archetypeAdvancedOptionsCollapsing"><input type="checkbox" id="archetypeAdvancedOptionsCollapsing" ng-model="dialogData.model.enableCollapsing"/><archetype-localize key="enableCollapsing">Enable Collapsing?</archetype-localize><small><archetype-localize key="enableCollapsingDescription">Enable fieldset collapsing.</archetype-localize></small></label>
         </div>
         <div>
             <label for="archetypeAdvancedOptionsMaxFieldsets"><archetype-localize key="maxFieldsets">Max Fieldsets</archetype-localize><small><archetype-localize key="maxFieldsetsDescription">How many Fieldsets are allowed? Entering '1' will disable the controls. Default is unlimited.</archetype-localize></small></label>
-            <input type="number" id="archetypeAdvancedOptionsMaxFieldsets" class="archetypeMaxFieldsets" ng-model="model.maxFieldsets"/>
+            <input type="number" id="archetypeAdvancedOptionsMaxFieldsets" class="archetypeMaxFieldsets" ng-model="dialogData.model.maxFieldsets"/>
         </div>
 
         <h4><archetype-localize key="fieldsetControls">Fieldset controls</archetype-localize></h4>
         <div>
-            <label for="archetypeAdvancedOptionsHideControls"><input type="checkbox" id="archetypeAdvancedOptionsHideControls" ng-model="model.hideFieldsetControls"/><archetype-localize key="hideFieldsetControls">Hide Fieldset Controls?</archetype-localize><small><archetype-localize key="hideFieldsetControlsDescription">Hides the fieldset add/remove/sort controls.</archetype-localize></small></label>
+            <label for="archetypeAdvancedOptionsHideControls"><input type="checkbox" id="archetypeAdvancedOptionsHideControls" ng-model="dialogData.model.hideFieldsetControls"/><archetype-localize key="hideFieldsetControls">Hide Fieldset Controls?</archetype-localize><small><archetype-localize key="hideFieldsetControlsDescription">Hides the fieldset add/remove/sort controls.</archetype-localize></small></label>
         </div>
 
         <div>
-            <label for="archetypeAdvancedOptionsCloning"><input type="checkbox" id="archetypeAdvancedOptionsCloning" ng-model="model.enableCloning"/><archetype-localize key="enableCloning">Enable Cloning?</archetype-localize><small><archetype-localize key="enableCloningDescription">Enable fieldset cloning.</archetype-localize></small></label>
+            <label for="archetypeAdvancedOptionsCloning"><input type="checkbox" id="archetypeAdvancedOptionsCloning" ng-model="dialogData.model.enableCloning"/><archetype-localize key="enableCloning">Enable Cloning?</archetype-localize><small><archetype-localize key="enableCloningDescription">Enable fieldset cloning.</archetype-localize></small></label>
         </div>
         <div>
-            <label for="archetypeAdvancedOptionsDisabling"><input type="checkbox" id="archetypeAdvancedOptionsDisabling" ng-model="model.enableDisabling" /><archetype-localize key="enableDisabling">Enable Fieldset Disabling?</archetype-localize><small><archetype-localize key="enableDisablingDescription">Allows fieldsets to be individually enabled/disabled.</archetype-localize></small></label>
+            <label for="archetypeAdvancedOptionsDisabling"><input type="checkbox" id="archetypeAdvancedOptionsDisabling" ng-model="dialogData.model.enableDisabling" /><archetype-localize key="enableDisabling">Enable Fieldset Disabling?</archetype-localize><small><archetype-localize key="enableDisablingDescription">Allows fieldsets to be individually enabled/disabled.</archetype-localize></small></label>
         </div>
         
         <h4><archetype-localize key="multipleFieldsets">Multiple fieldsets</archetype-localize></h4>
         <div>
-            <label for="archetypeAdvancedOptionsMultipleFieldsets"><input type="checkbox" id="archetypeAdvancedOptionsMultipleFieldsets" ng-model="model.enableMultipleFieldsets"/><archetype-localize key="enableMultipleFieldsets">Enable Multiple Fieldsets?</archetype-localize><small><archetype-localize key="enableMultipleFieldsetsDescription">Allows multiple types of fieldsets within this archetype.</archetype-localize></small></label>
+            <label for="archetypeAdvancedOptionsMultipleFieldsets"><input type="checkbox" id="archetypeAdvancedOptionsMultipleFieldsets" ng-model="dialogData.model.enableMultipleFieldsets"/><archetype-localize key="enableMultipleFieldsets">Enable Multiple Fieldsets?</archetype-localize><small><archetype-localize key="enableMultipleFieldsetsDescription">Allows multiple types of fieldsets within this archetype.</archetype-localize></small></label>
         </div>
 
-        <div ng-show="model.enableMultipleFieldsets">
+        <div ng-show="dialogData.model.enableMultipleFieldsets">
             <label><archetype-localize key="fieldsetGroups">Fieldset groups</archetype-localize></label>
             <small><archetype-localize key="fieldsetGroupsDescription">If you have a lot of fieldsets to choose from, you may want to consider grouping them in the fieldset picker. Once you have created your groups here, a group picker will be displayed in the fieldset editor and you can assign your fieldsets to their respective groups.</archetype-localize></small>
             <div class="archetypeFieldsetGroups">
-              <ul ui-sortable="sortableOptions" ng-model="model.fieldsetGroups">
-                  <li ng-repeat="fieldsetGroup in model.fieldsetGroups">
+              <ul ui-sortable="sortableOptions" ng-model="dialogData.model.fieldsetGroups">
+                  <li ng-repeat="fieldsetGroup in dialogData.model.fieldsetGroups">
                       <div>
                           <input id="archetypeFieldsetGroupName_{{$index}}" type="text" ng-model="fieldsetGroup.name" />
                           <i class="icon icon-delete" ng-click="removeFieldsetGroup($index)"></i>
-                          <i class="icon icon-navigation handle" ng-show="model.fieldsetGroups.length > 1"></i>
+                          <i class="icon icon-navigation handle" ng-show="dialogData.model.fieldsetGroups.length > 1"></i>
                       </div>
                   </li>
               </ul>

--- a/app/views/archetype.config.stylescript.dialog.html
+++ b/app/views/archetype.config.stylescript.dialog.html
@@ -4,19 +4,19 @@
         <h3><archetype-localize key="custom_style_script_options">Custom Style/Script Options</archetype-localize></h3>
         <div>
             <label for="archetypeAdvancedOptionsCustomClass"><archetype-localize key="customWrapperClass">Custom Wrapper Class</archetype-localize><small><archetype-localize key="customWrapperClassDescription">(Optional) Enter a custom CSS class that will be applied to the wrapper div.</archetype-localize></small></label>
-            <input type="text" id="archetypeAdvancedOptionsCustomClass" ng-model="model.customCssClass"/>
+            <input type="text" id="archetypeAdvancedOptionsCustomClass" ng-model="dialogData.model.customCssClass"/>
         </div>
         <div>
             <label for="archetypeAdvancedOptionsCustomCss"><archetype-localize key="cssFile">CSS File</archetype-localize><small><archetype-localize key="cssFileDescription">(Optional) Enter a path for a custom CSS file to be included on the page.</archetype-localize></small></label>
-            <input type="text" id="archetypeAdvancedOptionsCustomCss" ng-model="model.customCssPath"/>
+            <input type="text" id="archetypeAdvancedOptionsCustomCss" ng-model="dialogData.model.customCssPath"/>
         </div>
         <div>
             <label for="archetypeAdvancedOptionsCustomJs"><archetype-localize key="jsFile">JS File</archetype-localize><small><archetype-localize key="jsFileDescription">(Optional) Enter a path for a custom JS file to be included on the page.</archetype-localize></small></label>
-            <input type="text" id="archetypeAdvancedOptionsCustomJs" ng-model="model.customJsPath"/>
+            <input type="text" id="archetypeAdvancedOptionsCustomJs" ng-model="dialogData.model.customJsPath"/>
         </div>
         <div>
             <label for="archetypeAdvancedOptionsCustomView"><archetype-localize key="viewFile">View File</archetype-localize><small><archetype-localize key="viewFileDescription">(Optional) Enter a path for a custom view file to be used to render this Archetype.</archetype-localize></small></label>
-            <input type="text" id="archetypeAdvancedOptionsCustomView" ng-model="model.customViewPath"/>
+            <input type="text" id="archetypeAdvancedOptionsCustomView" ng-model="dialogData.model.customViewPath"/>
         </div>
     </div>
     <div class="umb-panel-footer">


### PR DESCRIPTION
By wrapping the render model in a new object and passing this new object as dialogData to the configuration dialogs, we can now explicitly detect if the entire render model was edited in the developer options dialog.