### PR TITLE
Adjust to 7.6 scheme for upload and image croppers

### DIFF
--- a/app/Umbraco/Umbraco.Archetype/PropertyEditors/ArcheTypePropertyEditor.cs
+++ b/app/Umbraco/Umbraco.Archetype/PropertyEditors/ArcheTypePropertyEditor.cs
@@ -219,6 +219,15 @@ namespace Archetype.PropertyEditors
 									}
 								}
 							}
+							// #397 - pass along "cuid" and "puid" (part of the Umbraco 7.6 scheme)
+							if(editorValue.AdditionalData.ContainsKey("cuid"))
+							{
+								additionalData["cuid"] = editorValue.AdditionalData["cuid"];
+							}
+							if(editorValue.AdditionalData.ContainsKey("puid"))
+							{
+								additionalData["puid"] = editorValue.AdditionalData["puid"];
+							}
 							var propData = new ContentPropertyData(propDef.Value, preValues, additionalData);
 							var propEditor = PropertyEditorResolver.Current.GetByAlias(dtd.PropertyEditorAlias);
 							// make sure to send the current property value (if any) to the PE ValueEditor


### PR DESCRIPTION
Fixes #397 - tested with:
- A newly created 7.6.3 site
- A 7.5.14 site upgraded to 7.6.3 (with EnablePropertyValueConverters set to `false`, see the official upgrade notes [here](https://our.umbraco.org/contribute/releases/763/))

Included in these tests are the built-in property editors:
- Image cropper
- Upload
- Content picker
- Content picker V2 (new 7.6 version)
- Media picker
- Media picker V2 (new 7.6 version)